### PR TITLE
[feat] 페이징 처리를 위한 ServiceUtil 도입 및 제목포함, 날짜순 다건 조회 구현#1

### DIFF
--- a/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
@@ -2,7 +2,6 @@ package com.back.domain.news.realNews.controller;
 
 import com.back.domain.news.realNews.dto.NaverNewsDto;
 import com.back.domain.news.realNews.dto.RealNewsDto;
-import com.back.domain.news.realNews.entity.RealNews;
 import com.back.domain.news.realNews.service.RealNewsService;
 import com.back.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,7 @@ public class RealNewsController {
 
     //추후 삭제예정 fetch 테스트
     @GetMapping("/fetch")
-    public RsData<List<NaverNewsDto>> fetchNewsByQuery(@RequestParam String query) {
+    public RsData<List<NaverNewsDto>> fetchMetaDataByQuery(@RequestParam String query) {
         List<NaverNewsDto> newsList = realNewsService.fetchNews(query);
         if (newsList.isEmpty()) {
             return RsData.of(404, "뉴스가 없습니다");
@@ -29,24 +28,27 @@ public class RealNewsController {
 
     //뉴스 생성
     @PostMapping("/create")
-    public RsData<List<RealNewsDto>> createNewsList(@RequestParam String query) {
-        List<RealNewsDto> realNewsList = realNewsService.createRealNews(query);
+    public RsData<List<RealNewsDto>> createRealNews(@RequestParam String query) {
+        List<RealNewsDto> realNewsList = realNewsService.createRealNewsDto(query);
 
         if (realNewsList.isEmpty()) {
             return RsData.of(404, String.format("'%s' 검색어로 뉴스를 찾을 수 없습니다", query));
         }
 
-        return RsData.of(200, "뉴스 생성 완료", realNewsList);
+        return RsData.of(200, String.format("뉴스 %d건 생성 완료",realNewsList.size()), realNewsList);
     }
 
     //단건조회
-    @GetMapping("{id}")
-    public RsData<RealNewsDto> getNewsDetail(@PathVariable Long id) {
+    @GetMapping("/{id}")
+    public RsData<RealNewsDto> getRealNewsById(@PathVariable Long id) {
         Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(id);
 
         return realNewsDto
                 .map(dto -> RsData.of(200, "조회 성공", dto))
                 .orElse(RsData.of(404, String.format("%d번의 뉴스를 찾을 수 없습니다", id)));
     }
+
+
+
 
 }

--- a/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
@@ -3,19 +3,28 @@ package com.back.domain.news.realNews.controller;
 import com.back.domain.news.realNews.dto.NaverNewsDto;
 import com.back.domain.news.realNews.dto.RealNewsDto;
 import com.back.domain.news.realNews.service.RealNewsService;
+import com.back.domain.news.util.NewsConstants;
+import com.back.domain.news.util.NewsPageService;
 import com.back.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
+
+import static org.springframework.data.domain.Sort.*;
+import static org.springframework.data.domain.Sort.Direction.*;
 
 @RestController
 @RequestMapping("api/real-news")
 @RequiredArgsConstructor
 public class RealNewsController {
     private final RealNewsService realNewsService;
-
+    private final NewsPageService newsPageService;
     //추후 삭제예정 fetch 테스트
     @GetMapping("/fetch")
     public RsData<List<NaverNewsDto>> fetchMetaDataByQuery(@RequestParam String query) {
@@ -43,12 +52,59 @@ public class RealNewsController {
     public RsData<RealNewsDto> getRealNewsById(@PathVariable Long id) {
         Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(id);
 
-        return realNewsDto
-                .map(dto -> RsData.of(200, "조회 성공", dto))
-                .orElse(RsData.of(404, String.format("%d번의 뉴스를 찾을 수 없습니다", id)));
+        return newsPageService.getSingleNews(realNewsDto, NewsConstants.REAL_NEWS, id);
     }
 
+    //다건조회(시간순)
+    @GetMapping
+    public RsData<Page<RealNewsDto>> getRealNewsList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String direction
+    ) {
+        if (!isValidPageParam(page, size, direction)) {
+            return RsData.of(400, "잘못된 페이지 파라미터입니다");
+        }
 
+        Direction sortDirection = fromString(direction);
+        Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
+
+        Pageable pageable = PageRequest.of(page-1, size, sortBy);
+        Page<RealNewsDto> RealNewsPage = realNewsService.getRealNewsList(pageable);
+
+        return newsPageService.getPagedNews(RealNewsPage, NewsConstants.REAL_NEWS);
+    }
+
+    //다건조회(검색)
+    @GetMapping("/search")
+    public RsData<Page<RealNewsDto>> searchRealNewsByTitle(
+            @RequestParam String title,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String direction
+    ) {
+        if (title == null || title.trim().isEmpty()) {
+            return RsData.of(400, "검색어를 입력해주세요");
+        }
+
+        if (!isValidPageParam(page, size, direction)) {
+            return RsData.of(400, "잘못된 페이지 파라미터입니다");
+        }
+
+        Direction sortDirection = fromString(direction);
+        Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
+
+        Pageable pageable = PageRequest.of(page-1, size, sortBy);
+        Page<RealNewsDto> RealNewsPage = realNewsService.searchRealNewsByTitle(title, pageable);
+
+        return newsPageService.getPagedNews(RealNewsPage, NewsConstants.REAL_NEWS);
+    }
+
+    private boolean isValidPageParam(int page, int size, String direction) {
+        return direction.equals("asc") || direction.equals("desc")
+                && page > 0
+                && size >= 1 && size <= 100;
+    }
 
 
 }

--- a/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
@@ -3,9 +3,11 @@ package com.back.domain.news.realNews.controller;
 import com.back.domain.news.realNews.dto.NaverNewsDto;
 import com.back.domain.news.realNews.dto.RealNewsDto;
 import com.back.domain.news.realNews.service.RealNewsService;
-import com.back.domain.news.util.NewsConstants;
 import com.back.domain.news.util.NewsPageService;
+import com.back.domain.news.util.NewsType;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,23 +21,17 @@ import java.util.Optional;
 import static org.springframework.data.domain.Sort.*;
 import static org.springframework.data.domain.Sort.Direction.*;
 
+@Tag(name = "RealNewsController", description = "Real News API")
 @RestController
 @RequestMapping("api/real-news")
 @RequiredArgsConstructor
 public class RealNewsController {
     private final RealNewsService realNewsService;
     private final NewsPageService newsPageService;
-    //추후 삭제예정 fetch 테스트
-    @GetMapping("/fetch")
-    public RsData<List<NaverNewsDto>> fetchMetaDataByQuery(@RequestParam String query) {
-        List<NaverNewsDto> newsList = realNewsService.fetchNews(query);
-        if (newsList.isEmpty()) {
-            return RsData.of(404, "뉴스가 없습니다");
-        }
-        return RsData.of(200, "뉴스 패치 완료", newsList);
-    }
+
 
     //뉴스 생성
+    @Operation(summary = "뉴스 생성", description = "네이버 뉴스 API와 데이터 파싱을 통해 뉴스를 생성합니다.")
     @PostMapping("/create")
     public RsData<List<RealNewsDto>> createRealNews(@RequestParam String query) {
         List<RealNewsDto> realNewsList = realNewsService.createRealNewsDto(query);
@@ -48,14 +44,16 @@ public class RealNewsController {
     }
 
     //단건조회
+    @Operation(summary = "단건 뉴스 조회", description = "ID로 단건 뉴스를 조회합니다.")
     @GetMapping("/{id}")
     public RsData<RealNewsDto> getRealNewsById(@PathVariable Long id) {
         Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(id);
 
-        return newsPageService.getSingleNews(realNewsDto, NewsConstants.REAL_NEWS, id);
+        return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, id);
     }
 
     //다건조회(시간순)
+    @Operation(summary = "다건 뉴스 조회", description = "페이지네이션을 통해 시간순으로 다건 뉴스를 조회합니다.")
     @GetMapping
     public RsData<Page<RealNewsDto>> getRealNewsList(
             @RequestParam(defaultValue = "1") int page,
@@ -72,10 +70,11 @@ public class RealNewsController {
         Pageable pageable = PageRequest.of(page-1, size, sortBy);
         Page<RealNewsDto> RealNewsPage = realNewsService.getRealNewsList(pageable);
 
-        return newsPageService.getPagedNews(RealNewsPage, NewsConstants.REAL_NEWS);
+        return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
     }
 
     //다건조회(검색)
+    @Operation(summary = "뉴스 검색", description = "제목으로 뉴스를 검색합니다.")
     @GetMapping("/search")
     public RsData<Page<RealNewsDto>> searchRealNewsByTitle(
             @RequestParam String title,
@@ -97,7 +96,7 @@ public class RealNewsController {
         Pageable pageable = PageRequest.of(page-1, size, sortBy);
         Page<RealNewsDto> RealNewsPage = realNewsService.searchRealNewsByTitle(title, pageable);
 
-        return newsPageService.getPagedNews(RealNewsPage, NewsConstants.REAL_NEWS);
+        return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
     }
 
     private boolean isValidPageParam(int page, int size, String direction) {
@@ -105,6 +104,5 @@ public class RealNewsController {
                 && page > 0
                 && size >= 1 && size <= 100;
     }
-
 
 }

--- a/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/realNews/controller/RealNewsController.java
@@ -101,7 +101,7 @@ public class RealNewsController {
     }
 
     private boolean isValidPageParam(int page, int size, String direction) {
-        return direction.equals("asc") || direction.equals("desc")
+        return (direction.equals("asc") || direction.equals("desc"))
                 && page > 0
                 && size >= 1 && size <= 100;
     }

--- a/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
@@ -1,7 +1,10 @@
 package com.back.domain.news.realNews.repository;
 
 import com.back.domain.news.realNews.entity.RealNews;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
+    Page<RealNews> findByTitleContaining(String title, Pageable pageable);
 }

--- a/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
@@ -270,8 +270,8 @@ public class RealNewsService {
                 .map(this::convertEntityToDto);
     }
 
-    public Page<RealNewsDto> getRealNewsList(Pageable paggeable) {
-        Page<RealNews> realNewsPage = realNewsRepository.findAll(paggeable);
+    public Page<RealNewsDto> getRealNewsList(Pageable pageable) {
+        Page<RealNews> realNewsPage = realNewsRepository.findAll(pageable);
         return realNewsPage.map(this::convertEntityToDto);
     }
 

--- a/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class RealNewsService {
     }
 
     // RealNewsDto를 생성하는 메서드
+    @Transactional
     public List<RealNewsDto> createRealNewsDto(String query) {
 
         try{
@@ -265,16 +267,19 @@ public class RealNewsService {
         );
     }
 
+    @Transactional(readOnly = true)
     public Optional<RealNewsDto> getRealNewsDtoById(Long id) {
         return realNewsRepository.findById(id)
                 .map(this::convertEntityToDto);
     }
 
+    @Transactional(readOnly = true)
     public Page<RealNewsDto> getRealNewsList(Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findAll(pageable);
         return realNewsPage.map(this::convertEntityToDto);
     }
 
+    @Transactional(readOnly = true)
     public Page<RealNewsDto> searchRealNewsByTitle(String title, Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findByTitleContaining(title, pageable);
         return realNewsPage.map(this::convertEntityToDto);

--- a/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
@@ -65,7 +65,7 @@ public class RealNewsService {
     }
 
     // RealNewsDto를 생성하는 메서드
-    public List<RealNewsDto> createRealNews(String query) {
+    public List<RealNewsDto> createRealNewsDto(String query) {
 
         try{
             List<NaverNewsDto> naverMetaDataList = fetchNews(query);
@@ -84,11 +84,11 @@ public class RealNewsService {
                 Thread.sleep(crawlingDelay);
             }
             // DTO → Entity 변환 후 저장
-            List<RealNews> realNewsList = convertRealNewsDtoToEntities(realNewsDtoList);
+            List<RealNews> realNewsList = convertDtosToEntities(realNewsDtoList);
             List<RealNews> savedEntities = realNewsRepository.saveAll(realNewsList); // 저장된 결과 받기
 
             // Entity → DTO 변환해서 반환
-            return convertRealNewsEntityToDtos(savedEntities);
+            return convertEntitiesToDtos(savedEntities);
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -223,13 +223,13 @@ public class RealNewsService {
         }
     }
 
-    private List<RealNews> convertRealNewsDtoToEntities (List<RealNewsDto> realNewsDtoList) {
+    private List<RealNews> convertDtosToEntities(List<RealNewsDto> realNewsDtoList) {
         return realNewsDtoList.stream()
-                .map(this::convertRealNewsDtoToEntity)
+                .map(this::convertDtoToEntity)
                 .collect(Collectors.toList());
     }
 
-    private RealNews convertRealNewsDtoToEntity(RealNewsDto realNewsDto) {
+    private RealNews convertDtoToEntity(RealNewsDto realNewsDto) {
         return new RealNews(
                 realNewsDto.title(),
                 realNewsDto.content(),
@@ -243,13 +243,13 @@ public class RealNewsService {
         );
     }
 
-    private List<RealNewsDto> convertRealNewsEntityToDtos(List<RealNews> realNewsList) {
+    private List<RealNewsDto> convertEntitiesToDtos(List<RealNews> realNewsList) {
         return realNewsList.stream()
-                .map(this::convertRealNewsEntityToDto)
+                .map(this::convertEntityToDto)
                 .collect(Collectors.toList());
     }
 
-    private RealNewsDto convertRealNewsEntityToDto(RealNews realNews) {
+    private RealNewsDto convertEntityToDto(RealNews realNews) {
         return RealNewsDto.of(
                 realNews.getTitle(),
                 realNews.getContent(),
@@ -263,11 +263,8 @@ public class RealNewsService {
         );
     }
 
-
-
-
     public Optional<RealNewsDto> getRealNewsDtoById(Long id) {
         return realNewsRepository.findById(id)
-                .map(this::convertRealNewsEntityToDto);
+                .map(this::convertEntityToDto);
     }
 }

--- a/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
@@ -16,6 +16,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -266,5 +268,15 @@ public class RealNewsService {
     public Optional<RealNewsDto> getRealNewsDtoById(Long id) {
         return realNewsRepository.findById(id)
                 .map(this::convertEntityToDto);
+    }
+
+    public Page<RealNewsDto> getRealNewsList(Pageable paggeable) {
+        Page<RealNews> realNewsPage = realNewsRepository.findAll(paggeable);
+        return realNewsPage.map(this::convertEntityToDto);
+    }
+
+    public Page<RealNewsDto> searchRealNewsByTitle(String title, Pageable pageable) {
+        Page<RealNews> realNewsPage = realNewsRepository.findByTitleContaining(title, pageable);
+        return realNewsPage.map(this::convertEntityToDto);
     }
 }

--- a/src/main/java/com/back/domain/news/util/NewsConstants.java
+++ b/src/main/java/com/back/domain/news/util/NewsConstants.java
@@ -1,0 +1,6 @@
+package com.back.domain.news.util;
+
+public class NewsConstants {
+    public static final String REAL_NEWS = "진짜";
+    public static final String FAKE_NEWS = "가짜";
+}

--- a/src/main/java/com/back/domain/news/util/NewsConstants.java
+++ b/src/main/java/com/back/domain/news/util/NewsConstants.java
@@ -1,6 +1,0 @@
-package com.back.domain.news.util;
-
-public class NewsConstants {
-    public static final String REAL_NEWS = "진짜";
-    public static final String FAKE_NEWS = "가짜";
-}

--- a/src/main/java/com/back/domain/news/util/NewsPageService.java
+++ b/src/main/java/com/back/domain/news/util/NewsPageService.java
@@ -1,0 +1,48 @@
+package com.back.domain.news.util;
+
+import com.back.global.rsData.RsData;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class NewsPageService {
+
+    public <T> RsData<Page<T>> getPagedNews(
+            Page<T> newsPage,
+            String newsType
+    ) {
+        if(newsPage.getTotalPages() == 0){
+            return RsData.of(404, String.format("%s 뉴스가 없습니다", newsType));
+        }
+        if(newsPage.isEmpty()) {
+            return RsData.of(
+                    400,
+                    String.format("요청한 페이지의 범위 초과. 총 %d페이지 중 %d페이지를 요청.",
+                    newsPage.getTotalPages(), newsPage.getNumber()+1));
+        }
+
+        return RsData.of(
+                200,
+                String.format("%s 뉴스 %d건 조회(전체 %d건)  [ %d / %d pages]",
+                        newsType,
+                        newsPage.getNumberOfElements(),
+                        newsPage.getTotalElements(),
+                        newsPage.getNumber()+1,
+                        newsPage.getTotalPages()),
+                newsPage
+        );
+    }
+
+    public <T> RsData<T> getSingleNews(
+            Optional<T> news,
+            String newsType,
+            Long id
+    ) {
+        return news
+                .map(dto -> RsData.of(200, "조회 성공", dto))
+                .orElse(RsData.of(404,
+                        String.format("%d 번의 %s 뉴스가 존재하지 않습니다", id, newsType)));
+    }
+}

--- a/src/main/java/com/back/domain/news/util/NewsPageService.java
+++ b/src/main/java/com/back/domain/news/util/NewsPageService.java
@@ -11,10 +11,11 @@ public class NewsPageService {
 
     public <T> RsData<Page<T>> getPagedNews(
             Page<T> newsPage,
-            String newsType
+            NewsType newsType
     ) {
+        String newsTypeDescription = newsType.getDescription();
         if(newsPage.getTotalPages() == 0){
-            return RsData.of(404, String.format("%s 뉴스가 없습니다", newsType));
+            return RsData.of(404, String.format("%s 뉴스가 없습니다", newsTypeDescription));
         }
         if(newsPage.isEmpty()) {
             return RsData.of(
@@ -37,12 +38,14 @@ public class NewsPageService {
 
     public <T> RsData<T> getSingleNews(
             Optional<T> news,
-            String newsType,
+            NewsType newsType,
             Long id
     ) {
+        String newsTypeDescription = newsType.getDescription();
+
         return news
                 .map(dto -> RsData.of(200, "조회 성공", dto))
                 .orElse(RsData.of(404,
-                        String.format("%d 번의 %s 뉴스가 존재하지 않습니다", id, newsType)));
+                        String.format("%d 번의 %s 뉴스가 존재하지 않습니다", id, newsTypeDescription)));
     }
 }

--- a/src/main/java/com/back/domain/news/util/NewsType.java
+++ b/src/main/java/com/back/domain/news/util/NewsType.java
@@ -1,0 +1,16 @@
+package com.back.domain.news.util;
+
+import lombok.Getter;
+
+@Getter
+public enum NewsType {
+    REAL("진짜"),
+    FAKE("가짜");
+
+    private final String description;
+
+    NewsType(String description) {
+        this.description = description;
+    }
+
+}


### PR DESCRIPTION
## 📢 기능 설명

페이징 서비스에 제네릭 사용하여 fakeNews에서도 사용할 수 있게 작성

getRealNewsList : /api/real-news?page=1&size=2&direction=desc <시간순 조회

searchRealNewsByTitle :/api/real-news/search?title=여름&page=1&size=2&direction=desc  <제목(containing)으로 조회

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #12
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 실제 뉴스 목록을 생성, 단일 뉴스 조회, 페이지네이션된 뉴스 목록 조회, 제목 검색 기능이 추가되었습니다.
  * 페이지네이션 및 정렬(asc/desc) 파라미터 검증이 적용되었습니다.
  * API 응답 메시지 및 상태 코드가 더욱 명확하게 개선되었습니다.
  * Swagger를 통한 API 문서화가 추가되었습니다.

* **개선 사항**
  * 일부 엔드포인트 및 메서드 명칭이 더 직관적으로 변경되었습니다.
  * 응답 메시지에 생성/조회된 뉴스 개수, 페이지 정보 등이 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->