### PR TITLE
[refactor] title 유니크 키 처리 및 제목 중복 사전 처리#1

### DIFF
--- a/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
@@ -24,6 +24,7 @@ public class RealNews {
     @GeneratedValue(strategy = IDENTITY)
     private long id;
 
+    @Column(unique = true)
     private String title;
 
     @Lob

--- a/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     Page<RealNews> findByTitleContaining(String title, Pageable pageable);
+
+    boolean existsByTitle(String title);
 }

--- a/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/realNews/service/RealNewsService.java
@@ -82,8 +82,14 @@ public class RealNewsService {
                     // 크롤링 실패 시 해당 뉴스는 건너뜀
                     continue;
                 }
+
                 RealNewsDto realNewsDto = MakeRealNewsFromInf(naverMetaData, newsDetailData);
-                realNewsDtoList.add(realNewsDto);
+
+                // 중복된 뉴스 제목이 있는지 확인
+                if(!realNewsRepository.existsByTitle(realNewsDto.title())){
+                    realNewsDtoList.add(realNewsDto);
+                }
+
 
                 Thread.sleep(crawlingDelay);
             }


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #61
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 중복된 뉴스 제목이 저장되지 않도록, 동일한 제목의 뉴스가 이미 존재할 경우 추가되지 않도록 개선되었습니다.  
* **신규 기능**
  * 뉴스 제목의 중복 저장을 방지하는 기능이 추가되었습니다.  
* **기타**
  * 데이터베이스에서 뉴스 제목의 유일성이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->