### PR TITLE
[feat] 가짜 뉴스 엔티티 생성 및 진짜 뉴스 카테고리 도입#1

### DIFF
--- a/src/main/java/com/back/domain/news/fakeNews/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fakeNews/entity/FakeNews.java
@@ -1,0 +1,22 @@
+package com.back.domain.news.fakeNews.entity;
+
+import com.back.domain.news.realNews.entity.RealNews;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class FakeNews {
+    @Id
+    private Long id;
+
+    @OneToOne
+    @MapsId // 진짜뉴스의 ID를 이 엔티티의 PK로 사용
+    @JoinColumn(name = "id")
+    private RealNews realNews;
+
+    private String title;
+
+    @Lob
+    private String content;
+}

--- a/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
@@ -45,7 +46,7 @@ public class RealNews {
     @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
     private List<DetailQuiz> detailQuizzes = new ArrayList<>();
 
-    @OneToOne(mappedBy = "realNews", cascade = ALL)
+    @OneToOne(mappedBy = "realNews", cascade = ALL, fetch = LAZY)
     private FakeNews fakeNews;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
@@ -1,6 +1,8 @@
 package com.back.domain.news.realNews.entity;
 
 
+import com.back.domain.news.fakeNews.entity.FakeNews;
+import com.back.domain.news.util.NewsCategory;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -13,6 +15,7 @@ import java.util.List;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
@@ -39,11 +42,14 @@ public class RealNews {
     private String journalist; // 뉴스 작성자 (기자)
 
     // 상세 퀴즈와 1:N 관계 설정 (RealNews 하나 당 3개의 DetailQuiz가 생성됩니다.)
-    @OneToMany(mappedBy = "realNews", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
     private List<DetailQuiz> detailQuizzes = new ArrayList<>();
 
-    // boolean is_fake    < 가짜 뉴스랑 1 대 1 매핑이면 필요없을 것 같음
-    // 카테고리id나 가짜테이블 연관설정은 테이블 추가될때 같이 수정할 예정
+    @OneToOne(mappedBy = "realNews", cascade = ALL)
+    private FakeNews fakeNews;
+
+    @Enumerated(EnumType.STRING)
+    private NewsCategory newsCategory;
 
     @Builder
     public RealNews(

--- a/src/main/java/com/back/domain/news/util/NewsCategory.java
+++ b/src/main/java/com/back/domain/news/util/NewsCategory.java
@@ -1,0 +1,18 @@
+package com.back.domain.news.util;
+
+import lombok.Getter;
+
+@Getter
+public enum NewsCategory {
+    SOCIETY("사회"),
+    ECONOMY("경제"),
+    POLITICS("정치"),
+    CULTURE("문화"),
+    IT("IT");
+
+    private String description;
+
+    NewsCategory(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #58
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 FakeNews 엔터티가 추가되어 가짜 뉴스의 제목과 내용을 저장할 수 있습니다.
  * RealNews 엔터티에 FakeNews와의 일대일 연관관계 및 뉴스 카테고리 필드가 추가되었습니다.
  * SOCIETY, ECONOMY, POLITICS, CULTURE, IT 등 다양한 뉴스 카테고리를 정의하는 NewsCategory 열거형이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->