### PR TITLE
[feat] RealNews 엔티티 수정 및 상세 퀴즈 생성 구현#1

### DIFF
--- a/src/main/java/com/back/BackendApplication.java
+++ b/src/main/java/com/back/BackendApplication.java
@@ -2,8 +2,12 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/realNews/entity/RealNews.java
@@ -8,18 +8,19 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-
-import java.time.LocalDateTime;
-
-import static jakarta.persistence.CascadeType.*;
-import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
 public class RealNews {
@@ -52,6 +53,9 @@ public class RealNews {
 
     @Enumerated(EnumType.STRING)
     private NewsCategory newsCategory;
+
+    @CreatedDate
+    private LocalDateTime createdDate; // 생성 날짜(DB에 저장된 날짜)
 
     @Builder
     public RealNews(

--- a/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/realNews/repository/RealNewsRepository.java
@@ -4,9 +4,18 @@ import com.back.domain.news.realNews.entity.RealNews;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     Page<RealNews> findByTitleContaining(String title, Pageable pageable);
 
     boolean existsByTitle(String title);
+
+    // 뉴스 가져오는 시간에 따라 쿼리 변경 가능성 있음
+    @Query("SELECT r FROM RealNews r WHERE r.createdDate >= :start AND r.createdDate < :end")
+    List<RealNews> findTodayNews(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizScheduledService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizScheduledService.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -17,14 +19,15 @@ public class DetailQuizScheduledService {
     private final DetailQuizAsyncService detailQuizAsyncService;
     private final RealNewsRepository realNewsRepository;
 
-    // 매일 오전 5시에 오늘 DB에 저장된 뉴스로 퀴즈 생성 (실제 뉴스는 오늘 날짜의 뉴스로 변경 필요)
+    // 매일 오전 5시에 오늘 DB에 저장된 뉴스로 퀴즈 생성
     @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
     public void generateQuizzesForTodayNews() {
-        // 뉴스 엔티티 변형 필요해 상의 후 진행
-        // List<RealNews> todayNews = realNewsRepository.findTodayNews(); // 오늘 날짜의 뉴스 조회
+        LocalDate today = LocalDate.now();
+        LocalDateTime start = today.atStartOfDay(); // 오늘 00:00
+        LocalDateTime end = today.plusDays(1).atStartOfDay(); // 내일 00:00
 
-        // 임시로 전체 뉴스 조회 (나중에 오늘 날짜의 뉴스로 변경)
-        List<RealNews> todayNews = realNewsRepository.findAll();
+        // 오늘 날짜의 뉴스 조회(시간 설정은 추후 변경 가능)
+        List<RealNews> todayNews = realNewsRepository.findTodayNews(start, end);
 
         if (todayNews.isEmpty()) {
             log.info("오늘 날짜의 뉴스 없음. 퀴즈 생성을 건너뜁니다.");


### PR DESCRIPTION
## 📢 기능 설명
상세 퀴즈 생성 과정 중 당일 DB에 저장된 뉴스들을 가져오는 로직을 추가
- RealNews 엔티티에 @CreatedDate createDate 필드 추가
- RealNewsRepository에 createDate를 기준으로 뉴스를 가져오는 @Query 메서드 추가
- DetailQuizScheduledService의 퀴즈 생성 메서드에 당일 저장된 뉴스 가져오는 로직 추가
- BackendApplication에 @CreatedDate 사용을 위한 @EnableScheduling 추가 (@Scheduled 사용을 위한 @EnableScheduling도 추가)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #73 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 뉴스 생성일 자동 기록 기능이 추가되어, 뉴스가 생성된 날짜가 자동으로 저장됩니다.
  * 오늘 생성된 뉴스만 조회하는 기능이 추가되었습니다.

* **버그 수정**
  * 퀴즈 자동 생성 시 오늘 생성된 뉴스만 대상으로 처리하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->