### PR TITLE
[feat] TodayNews 엔티티 생성

### DIFF
--- a/src/main/java/com/back/domain/news/common/dto/NaverNewsDto.java
+++ b/src/main/java/com/back/domain/news/common/dto/NaverNewsDto.java
@@ -1,4 +1,4 @@
-package com.back.domain.news.realNews.dto;
+package com.back.domain.news.common.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/src/main/java/com/back/domain/news/common/dto/NewsDetailDto.java
+++ b/src/main/java/com/back/domain/news/common/dto/NewsDetailDto.java
@@ -1,8 +1,6 @@
-package com.back.domain.news.realNews.dto;
+package com.back.domain.news.common.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.Builder;
-import lombok.Getter;
 
 //네이버 API로 조회한 뉴스의 링크 정보를 바탕으로 원본 링크에서 추출할 정보들을 담은 DTO
 public record NewsDetailDto(

--- a/src/main/java/com/back/domain/news/common/entity/KeywordHistory.java
+++ b/src/main/java/com/back/domain/news/common/entity/KeywordHistory.java
@@ -1,8 +1,7 @@
 package com.back.domain.news.common.entity;
 
 import com.back.domain.news.common.dto.KeywordWithType;
-import com.back.domain.news.common.enums.KeywordType;
-import com.back.domain.news.util.NewsCategory;
+import com.back.domain.news.common.enums.NewsCategory;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/back/domain/news/common/enums/NewsCategory.java
+++ b/src/main/java/com/back/domain/news/common/enums/NewsCategory.java
@@ -1,4 +1,4 @@
-package com.back.domain.news.util;
+package com.back.domain.news.common.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/back/domain/news/common/enums/NewsCategory.java
+++ b/src/main/java/com/back/domain/news/common/enums/NewsCategory.java
@@ -8,9 +8,10 @@ public enum NewsCategory {
     ECONOMY("경제"),
     POLITICS("정치"),
     CULTURE("문화"),
-    IT("IT");
+    IT("IT"),
+    NOT_FILTERED("필터링 전");
 
-    private String description;
+    private final String description;
 
     NewsCategory(String description) {
         this.description = description;

--- a/src/main/java/com/back/domain/news/common/enums/NewsType.java
+++ b/src/main/java/com/back/domain/news/common/enums/NewsType.java
@@ -1,4 +1,4 @@
-package com.back.domain.news.util;
+package com.back.domain.news.common.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/back/domain/news/common/service/KeywordHistoryService.java
+++ b/src/main/java/com/back/domain/news/common/service/KeywordHistoryService.java
@@ -5,7 +5,7 @@ import com.back.domain.news.common.dto.KeywordGenerationResDto;
 import com.back.domain.news.common.dto.KeywordWithType;
 import com.back.domain.news.common.entity.KeywordHistory;
 import com.back.domain.news.common.repository.KeywordHistoryRepository;
-import com.back.domain.news.util.NewsCategory;
+import com.back.domain.news.common.enums.NewsCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/back/domain/news/common/service/NewsPageService.java
+++ b/src/main/java/com/back/domain/news/common/service/NewsPageService.java
@@ -1,5 +1,6 @@
-package com.back.domain.news.util;
+package com.back.domain.news.common.service;
 
+import com.back.domain.news.common.enums.NewsType;
 import com.back.global.rsData.RsData;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
@@ -1,6 +1,6 @@
-package com.back.domain.news.fakeNews.entity;
+package com.back.domain.news.fake.entity;
 
-import com.back.domain.news.realNews.entity.RealNews;
+import com.back.domain.news.real.entity.RealNews;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
@@ -12,7 +12,7 @@ public class FakeNews {
 
     @OneToOne
     @MapsId // 진짜뉴스의 ID를 이 엔티티의 PK로 사용
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "real_news_id")
     private RealNews realNews;
 
     private String title;

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -1,10 +1,9 @@
-package com.back.domain.news.realNews.controller;
+package com.back.domain.news.real.controller;
 
-import com.back.domain.news.realNews.dto.NaverNewsDto;
-import com.back.domain.news.realNews.dto.RealNewsDto;
-import com.back.domain.news.realNews.service.RealNewsService;
-import com.back.domain.news.util.NewsPageService;
-import com.back.domain.news.util.NewsType;
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.RealNewsService;
+import com.back.domain.news.common.service.NewsPageService;
+import com.back.domain.news.common.enums.NewsType;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -67,9 +67,9 @@ public class RealNewsController {
         Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
 
         Pageable pageable = PageRequest.of(page-1, size, sortBy);
-        Page<RealNewsDto> RealNewsPage = realNewsService.getRealNewsList(pageable);
+        Page<RealNewsDto> realNewsPage = realNewsService.getRealNewsList(pageable);
 
-        return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
+        return newsPageService.getPagedNews(realNewsPage, NewsType.REAL);
     }
 
     //다건조회(검색)

--- a/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
+++ b/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
@@ -1,5 +1,6 @@
 package com.back.domain.news.real.dto;
 
+import com.back.domain.news.common.enums.NewsCategory;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.time.LocalDateTime;
@@ -13,7 +14,8 @@ public record RealNewsDto(
         LocalDateTime originCreatedDate,
         String mediaName,
         String journalist,
-        String originalNewsUrl
+        String originalNewsUrl,
+        NewsCategory newsCategory
 ) {
     public static RealNewsDto of(
             String title,
@@ -24,10 +26,11 @@ public record RealNewsDto(
             LocalDateTime originCreatedDate,
             String mediaName,
             String journalist,
-            String originalNewsUrl
+            String originalNewsUrl,
+            NewsCategory newsCategory
     ) {
         return new RealNewsDto(
-                title, content, description, link, imgUrl, originCreatedDate, mediaName, journalist, originalNewsUrl
+                title, content, description, link, imgUrl, originCreatedDate, mediaName, journalist, originalNewsUrl, newsCategory
         );
     }
 
@@ -41,8 +44,16 @@ public record RealNewsDto(
                 LocalDateTime.parse(item.get("originCreatedDate").asText()),
                 item.get("mediaName").asText(),
                 item.get("journalist").asText(),
-                item.get("originalNewsUrl").asText()
+                item.get("originalNewsUrl").asText(),
+                parseNewsCategory(item.get("newsCategory").asText())
         );
+    }
+    private static NewsCategory parseNewsCategory(String categoryStr) {
+        try {
+            return NewsCategory.valueOf(categoryStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return NewsCategory.SOCIETY;  // 기본값
+        }
     }
 }
 

--- a/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
+++ b/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
@@ -1,7 +1,6 @@
-package com.back.domain.news.realNews.dto;
+package com.back.domain.news.real.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.swagger.v3.core.util.Json;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -1,8 +1,8 @@
-package com.back.domain.news.realNews.entity;
+package com.back.domain.news.real.entity;
 
 
-import com.back.domain.news.fakeNews.entity.FakeNews;
-import com.back.domain.news.util.NewsCategory;
+import com.back.domain.news.fake.entity.FakeNews;
+import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -68,7 +68,8 @@ public class RealNews {
             LocalDateTime originCreatedDate,
             String mediaName,
             String journalist,
-            String originalNewsUrl) {
+            String originalNewsUrl,
+            NewsCategory newsCategory) {
         this.title = title;
         this.content = content;
         this.description = description;
@@ -78,6 +79,7 @@ public class RealNews {
         this.mediaName = mediaName;
         this.journalist = journalist;
         this.originalNewsUrl = originalNewsUrl;
+        this.newsCategory = newsCategory;
     }
 
 }

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -1,6 +1,6 @@
-package com.back.domain.news.realNews.repository;
+package com.back.domain.news.real.repository;
 
-import com.back.domain.news.realNews.entity.RealNews;
+import com.back.domain.news.real.entity.RealNews;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -1,10 +1,10 @@
-package com.back.domain.news.realNews.service;
+package com.back.domain.news.real.service;
 
-import com.back.domain.news.realNews.dto.NaverNewsDto;
-import com.back.domain.news.realNews.dto.NewsDetailDto;
-import com.back.domain.news.realNews.dto.RealNewsDto;
-import com.back.domain.news.realNews.entity.RealNews;
-import com.back.domain.news.realNews.repository.RealNewsRepository;
+import com.back.domain.news.common.dto.NaverNewsDto;
+import com.back.domain.news.common.dto.NewsDetailDto;
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.RealNewsRepository;
 import com.back.global.util.HtmlEntityDecoder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -2,6 +2,7 @@ package com.back.domain.news.real.service;
 
 import com.back.domain.news.common.dto.NaverNewsDto;
 import com.back.domain.news.common.dto.NewsDetailDto;
+import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.repository.RealNewsRepository;
@@ -195,7 +196,9 @@ public class RealNewsService {
                 parseNaverDate(naverNewsDto.pubDate()),
                 newsDetailDto.mediaName(),
                 newsDetailDto.journalist(),
-                naverNewsDto.originallink()
+                naverNewsDto.originallink(),
+                NewsCategory.NOT_FILTERED
+
         );
     }
 
@@ -252,7 +255,8 @@ public class RealNewsService {
                 realNewsDto.originCreatedDate(),
                 realNewsDto.mediaName(),
                 realNewsDto.journalist(),
-                realNewsDto.originalNewsUrl()
+                realNewsDto.originalNewsUrl(),
+                realNewsDto.newsCategory()
         );
     }
 
@@ -272,7 +276,8 @@ public class RealNewsService {
                 realNews.getOriginCreatedDate(),
                 realNews.getMediaName(),
                 realNews.getJournalist(),
-                realNews.getOriginalNewsUrl()
+                realNews.getOriginalNewsUrl(),
+                realNews.getNewsCategory()
         );
     }
 

--- a/src/main/java/com/back/domain/news/today/entity/TodayNews.java
+++ b/src/main/java/com/back/domain/news/today/entity/TodayNews.java
@@ -1,0 +1,35 @@
+package com.back.domain.news.today.entity;
+
+import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.quiz.detail.entity.DetailQuiz;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.*;
+
+@Entity
+@NoArgsConstructor
+public class TodayNews {
+    @Id
+    private Long id;
+
+    private LocalDate selectedDate;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "real_news_id")
+    private RealNews realNews;
+
+    @Builder
+    public TodayNews(LocalDate selectedDate, RealNews realNews) {
+        this.selectedDate = selectedDate;
+        this.realNews = realNews;
+    }
+}

--- a/src/main/java/com/back/domain/news/today/entity/TodaysNews.java
+++ b/src/main/java/com/back/domain/news/today/entity/TodaysNews.java
@@ -1,4 +1,0 @@
-package com.back.domain.news.today.entity;
-
-public class TodaysNews {
-}

--- a/src/main/java/com/back/domain/news/today/entity/TodaysNews.java
+++ b/src/main/java/com/back/domain/news/today/entity/TodaysNews.java
@@ -1,0 +1,4 @@
+package com.back.domain.news.today.entity;
+
+public class TodaysNews {
+}

--- a/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
+++ b/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
@@ -1,6 +1,6 @@
 package com.back.domain.quiz.detail.entity;
 
-import com.back.domain.news.realNews.entity.RealNews;
+import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.QuizType;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
 import jakarta.persistence.*;

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizScheduledService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizScheduledService.java
@@ -1,7 +1,7 @@
 package com.back.domain.quiz.detail.service;
 
-import com.back.domain.news.realNews.entity.RealNews;
-import com.back.domain.news.realNews.repository.RealNewsRepository;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.RealNewsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
@@ -1,7 +1,7 @@
 package com.back.domain.quiz.detail.service;
 
-import com.back.domain.news.realNews.entity.RealNews;
-import com.back.domain.news.realNews.repository.RealNewsRepository;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.RealNewsRepository;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
 import com.back.domain.quiz.detail.dto.DetailQuizReqDto;
 import com.back.domain.quiz.detail.entity.DetailQuiz;


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #80
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 특정 날짜에 선택된 뉴스를 나타내는 새로운 엔티티 TodayNews가 추가되었습니다.
  * 뉴스 카테고리에 "필터링 전(NOT_FILTERED)" 항목이 추가되었습니다.
  * 실제 뉴스(RealNews) 및 관련 DTO에 뉴스 카테고리 필드가 새롭게 포함되었습니다.

* **Chores**
  * 여러 클래스 및 엔티티의 패키지 구조가 일관성 있게 정리되었습니다.
  * 관련 import 경로가 새로운 패키지 구조에 맞게 수정되었습니다.
  * 일부 불필요한 import가 제거되었습니다.
  * 데이터베이스 컬럼명이 명확하게 변경되었습니다(예: real_news_id).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->