### PR TITLE
[feat] 팩트퀴즈 Entity 작성#1

### DIFF
--- a/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
@@ -1,8 +1,14 @@
 package com.back.domain.news.fake.entity;
 
 import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.quiz.fact.entity.FactQuiz;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.ALL;
 
 @Entity
 @NoArgsConstructor
@@ -19,4 +25,7 @@ public class FakeNews {
 
     @Lob
     private String content;
+
+    @OneToMany(mappedBy = "fakeNews", cascade = ALL, orphanRemoval = true)
+    private List<FactQuiz> factQuizzes = new ArrayList<>();
 }

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -1,9 +1,10 @@
 package com.back.domain.news.real.entity;
 
 
-import com.back.domain.news.fake.entity.FakeNews;
 import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.news.fake.entity.FakeNews;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
+import com.back.domain.quiz.fact.entity.FactQuiz;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,6 +48,9 @@ public class RealNews {
     // 상세 퀴즈와 1:N 관계 설정 (RealNews 하나 당 3개의 DetailQuiz가 생성됩니다.)
     @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
     private List<DetailQuiz> detailQuizzes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
+    private List<FactQuiz> factQuizzes = new ArrayList<>();
 
     @OneToOne(mappedBy = "realNews", cascade = ALL, fetch = LAZY)
     private FakeNews fakeNews;

--- a/src/main/java/com/back/domain/quiz/fact/entity/CorrectNewsType.java
+++ b/src/main/java/com/back/domain/quiz/fact/entity/CorrectNewsType.java
@@ -1,0 +1,6 @@
+package com.back.domain.quiz.fact.entity;
+
+public enum CorrectNewsType {
+    REAL, // 실제 뉴스
+    FAKE // 가짜 뉴스
+}

--- a/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
+++ b/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
@@ -5,18 +5,17 @@ import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.QuizType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@Service
 @NoArgsConstructor
 public class FactQuiz {
     @Id
@@ -28,19 +27,24 @@ public class FactQuiz {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "real_news_id", nullable = false)
+    @NotNull
     private RealNews realNews;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fake_news_id", nullable = false)
+    @NotNull
     private FakeNews fakeNews;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private CorrectNewsType correctNewsType;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private QuizType quizType = QuizType.FACT;
 
+
     @CreatedDate
-    private LocalDateTime createdDate; // 생성 날짜(DB에 저장된 날짜)
+    private LocalDateTime createdDate; // 생성 날짜(DB에 저장된 날짜)a
 
 }

--- a/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
+++ b/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
@@ -1,4 +1,46 @@
 package com.back.domain.quiz.fact.entity;
 
+import com.back.domain.news.fake.entity.FakeNews;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.quiz.QuizType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Service
+@NoArgsConstructor
 public class FactQuiz {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Question can not be blank")
+    private String question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "real_news_id", nullable = false)
+    private RealNews realNews;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fake_news_id", nullable = false)
+    private FakeNews fakeNews;
+
+    @Enumerated(EnumType.STRING)
+    private CorrectNewsType correctNewsType;
+
+    @Enumerated(EnumType.STRING)
+    private QuizType quizType = QuizType.FACT;
+
+    @CreatedDate
+    private LocalDateTime createdDate; // 생성 날짜(DB에 저장된 날짜)
+
 }


### PR DESCRIPTION
## 📢 기능 설명
진짜 뉴스와 가짜 뉴스를 구분하는 팩트 퀴즈 엔티티 구현
설계상 팩트퀴즈와 진짜뉴스/가짜뉴스는 @OneToOne이 맞지만 JPA 유연성을 고려해 @ManyToOne으로 설정했습니다
(서비스 로직에서 진짜뉴스/가짜뉴스 당 퀴즈 하나만 생성되도록 제약 조건 걸어둘 예정)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #28 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 실제 뉴스와 가짜 뉴스에 대한 퀴즈(FactQuiz) 관리 기능이 추가되었습니다.
  * FactQuiz 엔터티가 도입되어, 퀴즈 생성 시 실제 뉴스와 가짜 뉴스 항목을 연결할 수 있습니다.
  * 정답 유형을 REAL 또는 FAKE로 구분하는 CorrectNewsType 선택지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->