### PR TITLE
[feat] 유저 정보수정, 탈퇴 / 관리자 회원 다건,단건 조회 기능 구현 #1

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/AdmMemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/AdmMemberController.java
@@ -1,0 +1,69 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.member.member.dto.MemberWithInfoDto;
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@Tag(name = "AdmMemberController", description = "관리자 회원 단건, 다건 조회")
+public class AdmMemberController {
+
+    private final MemberService memberService;
+    private final Rq rq;
+
+
+    @Operation(summary = "(단건)회원 정보 조회- 관리자 전용 (아이디로 조회)")
+    @GetMapping("/members/{id}")
+    @Transactional
+    public RsData<MemberWithInfoDto> getMemberById(@PathVariable Long id) {
+        Member actor = rq.getActor();
+        if (actor == null || !actor.isAdmin()) {
+            throw new ServiceException(403, "관리자 권한이 필요합니다.");
+        }
+
+        Member member = memberService.findById(id)
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
+
+        return new RsData<>(
+                200,
+                "단건 회원 정보 조회 완료",
+                new MemberWithInfoDto(member)
+        );
+    }
+
+    @Operation(summary = "(다건)전제 회원 정보 조회-관리자 전용")
+    @GetMapping("/members")
+    @Transactional(readOnly = true)
+    public RsData<List<MemberWithInfoDto>> listMembers() {
+        Member actor = rq.getActor();
+        if (actor == null || !actor.isAdmin()) {
+            throw new ServiceException(403, "관리자 권한이 필요합니다.");
+        }
+
+        List<Member> members = memberService.findAll();
+
+        return new RsData<>(
+                200,
+                "전체 회원 정보 조회 완료",
+                members.stream()
+                        .map(MemberWithInfoDto::new)
+                        .toList()
+        );
+
+    }
+}

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -159,7 +159,7 @@ public class MemberController {
 
     }
 
-    @Operation(summary = "(단건)회원 정보 조회- 관리자 전용")
+    @Operation(summary = "(단건)회원 정보 조회- 관리자 전용 (아이디로 조회)")
     @GetMapping("/admin/members/{id}")
     @Transactional
     public RsData<MemberWithInfoDto> getMemberById(@PathVariable Long id) {

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -20,8 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -158,10 +156,10 @@ public class MemberController {
     }
 
     record ModifyReqBody(@NotBlank
-                         @Size(min = 5, max = 30, message = "이름은 최소 5자 이상이어야 합니다.")
+                         @Size(min = 2, max = 30, message = "이름은 최소 2자 이상이어야 합니다.")
                          String name,
                          @NotBlank
-                         @Size(min = 5, max = 50, message = "비밀번호는 최소 5자 이상이어야 합니다.")
+                         @Size(min = 10, max = 50)
                          String password,
                          @NotBlank
                          @Email(message = "유효한 이메일 형식이어야 합니다.")

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -200,13 +200,13 @@ public class MemberController {
     }
 
     record ModifyReqBody(@NotBlank
-                         @Size(min = 5, max = 25)
+                         @Size(min = 5, max = 30, message = "이름은 최소 5자 이상이어야 합니다.")
                          String name,
                          @NotBlank
-                         @Size(min = 5, max = 25)
+                         @Size(min = 5, max = 50, message = "비밀번호는 최소 5자 이상이어야 합니다.")
                          String password,
                          @NotBlank
-                         @Email
+                         @Email(message = "유효한 이메일 형식이어야 합니다.")
                          String email) {
     }
 
@@ -221,6 +221,14 @@ public class MemberController {
 
         Member member = memberService.findById(actor.getId())
                 .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
+
+        // 이메일 중복 체크
+        if(!member.getEmail().equals(reqBody.email())) {
+            memberService.findByEmail(reqBody.email())
+                    .ifPresent(_member -> {
+                        throw new ServiceException(409, "이미 존재하는 이메일입니다.");
+                    });
+        }
 
         memberService.modify(member, reqBody.name(), reqBody.password(), reqBody.email());
 

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -137,48 +137,6 @@ public class MemberController {
         );
     }
 
-
-    @Operation(summary = "(다건)전제 회원 정보 조회-관리자 전용")
-    @GetMapping("/admin/members")
-    @Transactional(readOnly = true)
-    public RsData<List<MemberWithInfoDto>> listMembers() {
-        Member actor = rq.getActor();
-        if (actor == null || !actor.isAdmin()) {
-            throw new ServiceException(403, "관리자 권한이 필요합니다.");
-        }
-
-        List<Member> members = memberService.findAll();
-
-        return new RsData<>(
-                200,
-                "전체 회원 정보 조회 완료",
-                members.stream()
-                        .map(MemberWithInfoDto::new)
-                        .toList()
-        );
-
-    }
-
-    @Operation(summary = "(단건)회원 정보 조회- 관리자 전용 (아이디로 조회)")
-    @GetMapping("/admin/members/{id}")
-    @Transactional
-    public RsData<MemberWithInfoDto> getMemberById(@PathVariable Long id) {
-        Member actor = rq.getActor();
-        if( actor == null || !actor.isAdmin()) {
-            throw new ServiceException(403, "관리자 권한이 필요합니다.");
-        }
-
-        Member member = memberService.findById(id)
-                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
-
-        return new RsData<>(
-                200,
-                "단건 회원 정보 조회 완료",
-                new MemberWithInfoDto(member)
-        );
-    }
-
-
     @Operation(summary = "회원 정보 조회 = 마이페이지")
     @GetMapping("/info")
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.back.domain.member.member.entity;
 
+import com.back.domain.member.quizhistory.QuizHistory;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
@@ -48,8 +49,8 @@ public class Member {
     private String apiKey; // 리프레시 토큰
 
     // 유저가 푼 퀴즈 기록을 저장하는 리스트 일단 엔티티 없어서 주석
-    //@OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
-    //private List<memberQuizAnswer> memberQuizAnswers = new ArrayList<>(); //유저가 퀴즈를 푼 기록
+    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizHistory> quizHistories = new ArrayList<>(); //유저가 퀴즈를 푼 기록
 
     public Member(long id, String email, String name) {
         setId(id);

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -66,7 +66,7 @@ public class MemberService {
     @Transactional
     public void modify(Member member, String name,  String password, String email) {
         member.setName(name);
-        member.setPassword(password);
+        member.setPassword(passwordEncoder.encode(password));
         member.setEmail(email);
         memberRepository.save(member);
     }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -75,5 +76,9 @@ public class MemberService {
             throw new ServiceException(403,"관리자는 탈퇴할 수 없습니다.");
 
         memberRepository.delete(member);
+    }
+
+    public List<Member> findAll() {
+        return memberRepository.findAll();
     }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -2,9 +2,11 @@ package com.back.domain.member.member.service;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
+import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.Optional;
@@ -58,5 +60,20 @@ public class MemberService {
 
     public Member save(Member member) {
         return memberRepository.save(member);
+    }
+
+    @Transactional
+    public void modify(Member member, String name,  String password, String email) {
+        member.setName(name);
+        member.setPassword(password);
+        member.setEmail(email);
+        memberRepository.save(member);
+    }
+
+    public void withdraw(Member member) {
+        if(member.isAdmin())
+            throw new ServiceException(403,"관리자는 탈퇴할 수 없습니다.");
+
+        memberRepository.delete(member);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
유저가 정보수정, 탈퇴가능하게 기능 구현
관리지가 유저의 정보를 불러오는 다건, 단건 조회 기능 구현

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #83 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 모든 회원 목록 및 개별 회원 상세 정보를 조회할 수 있는 기능이 추가되었습니다.
  * 사용자가 자신의 이름, 비밀번호, 이메일을 수정할 수 있는 기능이 추가되었습니다.
  * 사용자가 직접 회원 탈퇴(계정 삭제)를 할 수 있는 기능이 추가되었습니다.
  * 회원의 퀴즈 히스토리를 관리하는 기능이 추가되었습니다.

* **버그 수정**
  * 일부 메서드의 포맷팅이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->