### PR TITLE
[Feat] RealNewsController (for user) 와 AdminNewsController의 분리 및 오늘의 뉴스 설정 기능 추가

### DIFF
--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -1,0 +1,63 @@
+package com.back.domain.news.real.controller;
+
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.AdminNewsService;
+import com.back.domain.news.real.service.RealNewsService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/admin/news")
+@RequiredArgsConstructor
+public class AdminNewsController {
+    private final AdminNewsService adminNewsService;
+    private final RealNewsService realNewsService;
+
+    //뉴스 삭제
+    @Operation(summary = "뉴스 삭제", description = "ID로 뉴스를 삭제합니다.")
+    @DeleteMapping("/{newsId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public RsData<Void> deleteRealNews(@PathVariable Long newsId) {
+        boolean deleted = adminNewsService.deleteRealNews(newsId);
+
+        if(!deleted){
+            return RsData.of(404, String.format("ID %d에 해당하는 뉴스가 존재하지 않습니다", newsId));
+        }
+
+        return RsData.of(200, String.format("%d번 뉴스 삭제 완료", newsId));
+    }
+
+    @Operation(summary = "오늘의 뉴스 설정", description = "오늘의 뉴스를 설정합니다.")
+    @PostMapping("/today/select/{newsId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public RsData<RealNewsDto> setTodayNews(@PathVariable Long newsId) {
+
+        try {
+            // 1. 뉴스 존재 여부 확인
+            Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(newsId);
+            if (realNewsDto.isEmpty()) {
+                return RsData.of(404, String.format("ID %d에 해당하는 뉴스가 존재하지 않습니다", newsId));
+            }
+            // 2. 이미 오늘의 뉴스인지 확인 (서비스에서 처리)
+            if (adminNewsService.isAlreadyTodayNews(newsId)) {
+                return RsData.of(400, "이미 오늘의 뉴스로 설정되어 있습니다.", realNewsDto.get());
+            }
+
+            adminNewsService.setTodayNews(newsId);
+
+            return RsData.of(200, "오늘의 뉴스가 설정되었습니다.", realNewsDto.get());
+
+        } catch (IllegalArgumentException e) {
+            return RsData.of(400, e.getMessage());
+        } catch (Exception e) {
+            return RsData.of(500, "오늘의 뉴스 설정 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -72,9 +72,9 @@ public class AdminNewsController {
             return RsData.of(200, "오늘의 뉴스가 설정되었습니다.", realNewsDto.get());
 
         } catch (IllegalArgumentException e) {
-            return RsData.of(400, "잘못된 요청입니다. POST 요청이 맞는지 확인하세요");
+            return RsData.of(400, e.getMessage());
         } catch (Exception e) {
-            return RsData.of(500, "오늘의 뉴스 설정 중 오류가 발생했습니다.");
+            return RsData.of(500, "오늘의 뉴스 설정 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -11,19 +11,37 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/admin/news")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminNewsController {
     private final AdminNewsService adminNewsService;
     private final RealNewsService realNewsService;
 
+
+
+    //뉴스 생성
+    @Operation(summary = "뉴스 생성", description = "네이버 뉴스 API와 데이터 파싱을 통해 뉴스를 생성합니다.")
+    @PostMapping("/create")
+    public RsData<List<RealNewsDto>> createRealNews(@RequestParam String query) {
+        List<RealNewsDto> realNewsList = adminNewsService.createRealNewsDto(query);
+
+        if (realNewsList.isEmpty()) {
+            return RsData.of(404, String.format("'%s' 검색어로 뉴스를 찾을 수 없습니다", query));
+        }
+
+        return RsData.of(200, String.format("뉴스 %d건 생성 완료",realNewsList.size()), realNewsList);
+    }
+
+
     //뉴스 삭제
     @Operation(summary = "뉴스 삭제", description = "ID로 뉴스를 삭제합니다.")
     @DeleteMapping("/{newsId}")
-    @PreAuthorize("hasRole('ADMIN')")
+
     public RsData<Void> deleteRealNews(@PathVariable Long newsId) {
         boolean deleted = adminNewsService.deleteRealNews(newsId);
 
@@ -36,7 +54,6 @@ public class AdminNewsController {
 
     @Operation(summary = "오늘의 뉴스 설정", description = "오늘의 뉴스를 설정합니다.")
     @PostMapping("/today/select/{newsId}")
-    @PreAuthorize("hasRole('ADMIN')")
     public RsData<RealNewsDto> setTodayNews(@PathVariable Long newsId) {
 
         try {
@@ -55,7 +72,7 @@ public class AdminNewsController {
             return RsData.of(200, "오늘의 뉴스가 설정되었습니다.", realNewsDto.get());
 
         } catch (IllegalArgumentException e) {
-            return RsData.of(400, e.getMessage());
+            return RsData.of(400, "잘못된 요청입니다. POST 요청이 맞는지 확인하세요");
         } catch (Exception e) {
             return RsData.of(500, "오늘의 뉴스 설정 중 오류가 발생했습니다.");
         }

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -12,6 +12,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -98,18 +101,7 @@ public class RealNewsController {
         return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
     }
 
-    //뉴스 삭제
-    @Operation(summary = "뉴스 삭제", description = "ID로 뉴스를 삭제합니다.")
-    @DeleteMapping("/{id}")
-    public RsData<Void> deleteRealNews(@PathVariable Long id) {
-        boolean deleted = realNewsService.deleteRealNews(id);
 
-        if(!deleted){
-            return RsData.of(404, String.format("ID %d에 해당하는 뉴스가 존재하지 않습니다", id));
-        }
-
-        return RsData.of(200, String.format("%d번 뉴스 삭제 완료", id));
-    }
 
     private boolean isValidPageParam(int page, int size, String direction) {
         return (direction.equals("asc") || direction.equals("desc"))

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -25,33 +25,32 @@ import static org.springframework.data.domain.Sort.Direction.*;
 
 @Tag(name = "RealNewsController", description = "Real News API")
 @RestController
-@RequestMapping("api/real-news")
+@RequestMapping("api/news")
 @RequiredArgsConstructor
 public class RealNewsController {
     private final RealNewsService realNewsService;
     private final NewsPageService newsPageService;
 
 
-    //뉴스 생성
-    @Operation(summary = "뉴스 생성", description = "네이버 뉴스 API와 데이터 파싱을 통해 뉴스를 생성합니다.")
-    @PostMapping("/create")
-    public RsData<List<RealNewsDto>> createRealNews(@RequestParam String query) {
-        List<RealNewsDto> realNewsList = realNewsService.createRealNewsDto(query);
-
-        if (realNewsList.isEmpty()) {
-            return RsData.of(404, String.format("'%s' 검색어로 뉴스를 찾을 수 없습니다", query));
-        }
-
-        return RsData.of(200, String.format("뉴스 %d건 생성 완료",realNewsList.size()), realNewsList);
-    }
 
     //단건조회
     @Operation(summary = "단건 뉴스 조회", description = "ID로 단건 뉴스를 조회합니다.")
-    @GetMapping("/{id}")
-    public RsData<RealNewsDto> getRealNewsById(@PathVariable Long id) {
-        Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(id);
+    @GetMapping("/{newsId}")
+    public RsData<RealNewsDto> getRealNewsById(@PathVariable Long newsId) {
 
-        return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, id);
+        if (newsId == null || newsId <= 0) {
+            return RsData.of(400, "잘못된 뉴스 ID입니다. 1 이상의 숫자를 입력해주세요.");
+        }
+
+        Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(newsId);
+
+        if (realNewsDto.isEmpty()) {
+            return RsData.of(404,
+                    String.format("ID %d에 해당하는 뉴스를 찾을 수 없습니다. 올바른 뉴스 ID인지 확인해주세요.", newsId));
+        }
+
+
+        return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, newsId);
     }
 
     //다건조회(시간순)
@@ -100,8 +99,6 @@ public class RealNewsController {
 
         return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
     }
-
-
 
     private boolean isValidPageParam(int page, int size, String direction) {
         return (direction.equals("asc") || direction.equals("desc"))

--- a/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
+++ b/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
@@ -52,7 +52,7 @@ public record RealNewsDto(
         try {
             return NewsCategory.valueOf(categoryStr.toUpperCase());
         } catch (IllegalArgumentException e) {
-            return NewsCategory.SOCIETY;  // 기본값
+            return NewsCategory.NOT_FILTERED;
         }
     }
 }

--- a/src/main/java/com/back/domain/news/real/mapper/RealNewsMapper.java
+++ b/src/main/java/com/back/domain/news/real/mapper/RealNewsMapper.java
@@ -1,0 +1,55 @@
+package com.back.domain.news.real.mapper;
+
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.entity.RealNews;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RealNewsMapper {
+    public List<RealNews> toEntityList(List<RealNewsDto> realNewsDtoList) {
+        return realNewsDtoList.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+    }
+
+    public RealNews toEntity(RealNewsDto realNewsDto) {
+        return new RealNews(
+                realNewsDto.title(),
+                realNewsDto.content(),
+                realNewsDto.description(),
+                realNewsDto.link(),
+                realNewsDto.imgUrl(),
+                realNewsDto.originCreatedDate(),
+                realNewsDto.mediaName(),
+                realNewsDto.journalist(),
+                realNewsDto.originalNewsUrl(),
+                realNewsDto.newsCategory()
+        );
+    }
+
+    public List<RealNewsDto> toDtoList(List<RealNews> realNewsList) {
+        return realNewsList.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public RealNewsDto toDto(RealNews realNews) {
+        return RealNewsDto.of(
+                realNews.getTitle(),
+                realNews.getContent(),
+                realNews.getDescription(),
+                realNews.getLink(),
+                realNews.getImgUrl(),
+                realNews.getOriginCreatedDate(),
+                realNews.getMediaName(),
+                realNews.getJournalist(),
+                realNews.getOriginalNewsUrl(),
+                realNews.getNewsCategory()
+        );
+    }
+
+
+}

--- a/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
@@ -1,0 +1,15 @@
+package com.back.domain.news.real.repository;
+
+import com.back.domain.news.today.entity.TodayNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
+
+    @Modifying
+    @Transactional
+    void deleteBySelectedDate(LocalDate today);
+}

--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -1,15 +1,36 @@
 package com.back.domain.news.real.service;
 
+import com.back.domain.news.common.dto.NaverNewsDto;
+import com.back.domain.news.common.dto.NewsDetailDto;
+import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.mapper.RealNewsMapper;
 import com.back.domain.news.real.repository.RealNewsRepository;
 import com.back.domain.news.real.repository.TodayNewsRepository;
 import com.back.domain.news.today.entity.TodayNews;
+import com.back.global.util.HtmlEntityDecoder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Service
@@ -17,7 +38,210 @@ import java.util.Optional;
 public class AdminNewsService {
     private final RealNewsRepository realNewsRepository;
     private final TodayNewsRepository todayNewsRepository;
+    private final RealNewsMapper realNewsMapper;
 
+    // HTTP 요청을 보내기 위한 Spring의 HTTP 클라이언트(외부 API 호출 시 사용)
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${NAVER_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${NAVER_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${naver.news.display}")
+    private int newsDisplayCount;
+
+    @Value("${naver.news.sort:sim}")
+    private String newsSortOrder;
+
+    @Value("${naver.crawling.delay}")
+    private int crawlingDelay;
+
+    @Value("${naver.base-url}")
+    private String naverUrl;
+
+    // 서비스 초기화 시 설정값 검증
+    @PostConstruct
+    public void validateConfig(){
+        if (clientId == null || clientId.isEmpty()) {
+            throw new IllegalArgumentException("NAVER_CLIENT_ID가 설정되지 않았습니다.");
+        }
+        if (clientSecret == null || clientSecret.isEmpty()) {
+            throw new IllegalArgumentException("NAVER_CLIENT_SECRET가 설정되지 않았습니다.");
+        }
+        if (newsDisplayCount < 1 || newsDisplayCount >10) {
+            throw new IllegalArgumentException("NAVER_NEWS_DISPLAY_COUNT는 1에서 10 사이의 값이어야 합니다.");
+        }
+    }
+
+    // RealNewsDto를 생성하는 메서드
+    @Transactional
+    public List<RealNewsDto> createRealNewsDto(String query) {
+
+        try{
+            List<NaverNewsDto> naverMetaDataList = fetchNews(query);
+            List<RealNewsDto> realNewsDtoList = new ArrayList<>();
+
+            for(NaverNewsDto naverMetaData : naverMetaDataList) {
+                NewsDetailDto newsDetailData = crawlAddtionalInfo(naverMetaData.link());
+
+                if(newsDetailData == null) {
+                    // 크롤링 실패 시 해당 뉴스는 건너뜀
+                    continue;
+                }
+
+                RealNewsDto realNewsDto = MakeRealNewsFromInf(naverMetaData, newsDetailData);
+
+                // 중복된 뉴스 제목이 있는지 확인
+                if(!realNewsRepository.existsByTitle(realNewsDto.title())){
+                    realNewsDtoList.add(realNewsDto);
+                }
+
+
+                Thread.sleep(crawlingDelay);
+            }
+            // DTO → Entity 변환 후 저장
+            List<RealNews> realNewsList = realNewsMapper.toEntityList(realNewsDtoList);
+            List<RealNews> savedEntities = realNewsRepository.saveAll(realNewsList); // 저장된 결과 받기
+
+            // Entity → DTO 변환해서 반환
+            return realNewsMapper.toDtoList(savedEntities);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("스레드 인터럽트 발생" );
+        }
+    }
+
+    //N건 패치
+    //예상되는 문제 : 최신순으로 하면 겹치는 부분이 많을 것 같음
+    //주요기사를 받아오는 로직이 필요할 것 같은데... 쉽지않을듯 자체적으론 힘들듯하고 우선 ai 프롬프트를 잘 만져봐야할 것 같습니다.
+    public List<NaverNewsDto> fetchNews(String query) {
+
+        try {
+            //display는 한 번에 보여줄 뉴스의 개수, sort는 정렬 기준 (date: 최신순, sim: 정확도순)
+            //일단 3건 패치하도록 해놨습니다. yml 에서 작성해서 사용하세요(10건 이상 x)
+            String url = naverUrl + query + "&display=" + newsDisplayCount + "&sort=" + newsSortOrder;
+
+            // http 요청 헤더 설정 (아래는 네이버 디폴트 형식)
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-Naver-Client-Id", clientId);
+            headers.set("X-Naver-Client-Secret", clientSecret);
+
+            // http 요청 엔티티(헤더+바디) 생성
+            // get이라 본문은 없고 헤더만 포함 -> 아래에서 string = null로 설정
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            //http 요청 수행
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url, HttpMethod.GET, entity, String.class, query);
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                // JsonNode: json 구조를 트리 형태로 표현. json의 중첩 구조를 탐색할 때 사용
+                // readTree(): json 문자열을 JsonNode 트리로 변환
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode items = mapper.readTree(response.getBody()).get("items");
+
+                if (items != null) {
+                    return getNewsMetaDataFromNaverApi(items);
+                }
+                return new ArrayList<>();
+            }
+            throw new RuntimeException("네이버 API 요청 실패");
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 파싱 실패");
+        }
+    }
+
+    // 단건 크롤링
+    public NewsDetailDto crawlAddtionalInfo(String naverNewsUrl) {
+        try{
+            Document doc = Jsoup.connect(naverNewsUrl)
+                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")  // 브라우저인 척
+                    .get();  // GET 요청으로 HTML 가져오기 (robots.txt에 걸리지 않도록)
+
+            String content = Optional.ofNullable(doc.selectFirst("article#dic_area"))
+                    .map(Element::text)
+                    .orElse("");
+            String imgUrl = Optional.ofNullable(doc.selectFirst("#img1"))
+                    .map(element -> element.attr("data-src"))
+                    .orElse("");
+
+            String journalist = Optional.ofNullable(doc.selectFirst("em.media_end_head_journalist_name"))
+                    .map(Element::text)
+                    .orElse("");
+            String mediaName = Optional.ofNullable(doc.selectFirst("img.media_end_head_top_logo_img"))
+                    .map(elem -> elem.attr("alt"))
+                    .orElse("");
+
+            // 크롤링한 정보가 비어있으면 null 반환
+            if(content.isEmpty() || imgUrl.isEmpty() || journalist.isEmpty() || mediaName.isEmpty()) {
+                return null;
+            }
+
+            return NewsDetailDto.of(content, imgUrl, journalist, mediaName);
+
+        } catch (IOException e) {
+            //  Jsoup 연결 실패 시
+            throw new RuntimeException("크롤링 실패");
+        }
+    }
+
+    // 네이버 api에서 받아온 정보와 크롤링한 상세 정보를 바탕으로 RealNewsDto 생성
+    public RealNewsDto MakeRealNewsFromInf(NaverNewsDto naverNewsDto, NewsDetailDto newsDetailDto) {
+        return RealNewsDto.of(
+                naverNewsDto.title(),
+                newsDetailDto.content(),
+                naverNewsDto.description(),
+                naverNewsDto.link(),
+                newsDetailDto.imgUrl(),
+                parseNaverDate(naverNewsDto.pubDate()),
+                newsDetailDto.mediaName(),
+                newsDetailDto.journalist(),
+                naverNewsDto.originallink(),
+                NewsCategory.NOT_FILTERED
+
+        );
+    }
+
+    // fetchNews 메서드로 네이버 API에서 뉴스 목록을 가져오고
+    // 링크 정보를 바탕으로 상세 정보를 crawlAddtionalInfo 메서드로 크롤링하여 RealNews 객체를 생성
+    private List<NaverNewsDto> getNewsMetaDataFromNaverApi(JsonNode items){
+        List<NaverNewsDto> newsMetaDataList = new ArrayList<>();
+
+        for (JsonNode item : items) {
+            String rawTitle = item.get("title").asText("");
+            String originallink = item.get("originallink").asText("");
+            String link = item.get("link").asText("");
+            String rawDdscription = item.get("description").asText("");
+            String pubDate = item.get("pubDate").asText("");
+
+            String cleanedTitle = HtmlEntityDecoder.decode(rawTitle); // HTML 태그 제거
+            String cleanDescription = HtmlEntityDecoder.decode(rawDdscription); // HTML 태그 제거
+
+            //한 필드라도 비어있으면 건너뜀
+            if(cleanedTitle.isEmpty()|| originallink.isEmpty() || link.isEmpty() || cleanDescription.isEmpty() || pubDate.isEmpty())
+                continue;
+            //팩토리 메서드 사용
+            NaverNewsDto newsDto = NaverNewsDto.of(cleanedTitle, originallink, link, cleanDescription, pubDate);
+            newsMetaDataList.add(newsDto);
+        }
+
+        return newsMetaDataList;
+    }
+
+    // 네이버 API에서 받아온 날짜 문자열을 LocalDateTime으로 변환
+    private LocalDateTime parseNaverDate(String naverDate) {
+        try {
+            String dateTimeFormat = HtmlEntityDecoder.decode(naverDate);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm", Locale.ENGLISH);
+            return LocalDateTime.parse(dateTimeFormat , formatter);
+        } catch (Exception e) {
+            return LocalDateTime.now(); // 파싱 실패 시 현재 시간
+        }
+    }
     @Transactional
     public boolean deleteRealNews(Long newsId) {
         Optional<RealNews> realNewsOpt = realNewsRepository.findById(newsId);

--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -1,0 +1,58 @@
+package com.back.domain.news.real.service;
+
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.RealNewsRepository;
+import com.back.domain.news.real.repository.TodayNewsRepository;
+import com.back.domain.news.today.entity.TodayNews;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminNewsService {
+    private final RealNewsRepository realNewsRepository;
+    private final TodayNewsRepository todayNewsRepository;
+
+    @Transactional
+    public boolean deleteRealNews(Long newsId) {
+        Optional<RealNews> realNewsOpt = realNewsRepository.findById(newsId);
+
+        if (realNewsOpt.isEmpty()) {
+            return false;  // 뉴스가 없으면 false 반환
+        }
+
+        if (todayNewsRepository.existsById(newsId)) {
+            todayNewsRepository.deleteById(newsId);
+        }
+        // 뉴스 삭제 (FakeNews도 CASCADE로 함께 삭제됨)
+        realNewsRepository.deleteById(newsId);
+        return true;
+    }
+
+
+    public boolean isAlreadyTodayNews(Long id) {
+        return todayNewsRepository.existsById(id);
+    }
+
+    @Transactional
+    public void setTodayNews(Long id) {
+        RealNews realNews = realNewsRepository.findById(id).
+                orElseThrow(() -> new IllegalArgumentException("해당 ID의 뉴스가 존재하지 않습니다. ID: " + id));
+
+        LocalDate today = LocalDate.now();
+        todayNewsRepository.deleteBySelectedDate(today);
+
+        // 5. 새로운 오늘의 뉴스 생성
+        TodayNews todayNews = TodayNews.builder()
+                .selectedDate(today)
+                .realNews(realNews)
+                .build();
+
+        todayNewsRepository.save(todayNews);
+    }
+}

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -5,6 +5,7 @@ import com.back.domain.news.common.dto.NewsDetailDto;
 import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.mapper.RealNewsMapper;
 import com.back.domain.news.real.repository.RealNewsRepository;
 import com.back.global.util.HtmlEntityDecoder;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,268 +37,23 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RealNewsService {
     private final RealNewsRepository realNewsRepository;
-    // HTTP 요청을 보내기 위한 Spring의 HTTP 클라이언트(외부 API 호출 시 사용)
-    private final RestTemplate restTemplate = new RestTemplate();
-
-    @Value("${NAVER_CLIENT_ID}")
-    private String clientId;
-
-    @Value("${NAVER_CLIENT_SECRET}")
-    private String clientSecret;
-
-    @Value("${naver.news.display}")
-    private int newsDisplayCount;
-
-    @Value("${naver.news.sort:sim}")
-    private String newsSortOrder;
-
-    @Value("${naver.crawling.delay}")
-    private int crawlingDelay;
-
-    @Value("${naver.base-url}")
-    private String naverUrl;
-
-    // 서비스 초기화 시 설정값 검증
-    @PostConstruct
-    public void validateConfig(){
-        if (clientId == null || clientId.isEmpty()) {
-            throw new IllegalArgumentException("NAVER_CLIENT_ID가 설정되지 않았습니다.");
-        }
-        if (clientSecret == null || clientSecret.isEmpty()) {
-            throw new IllegalArgumentException("NAVER_CLIENT_SECRET가 설정되지 않았습니다.");
-        }
-        if (newsDisplayCount < 1 || newsDisplayCount >10) {
-            throw new IllegalArgumentException("NAVER_NEWS_DISPLAY_COUNT는 1에서 10 사이의 값이어야 합니다.");
-        }
-    }
-
-    // RealNewsDto를 생성하는 메서드
-    @Transactional
-    public List<RealNewsDto> createRealNewsDto(String query) {
-
-        try{
-            List<NaverNewsDto> naverMetaDataList = fetchNews(query);
-            List<RealNewsDto> realNewsDtoList = new ArrayList<>();
-
-            for(NaverNewsDto naverMetaData : naverMetaDataList) {
-                NewsDetailDto newsDetailData = crawlAddtionalInfo(naverMetaData.link());
-
-                if(newsDetailData == null) {
-                    // 크롤링 실패 시 해당 뉴스는 건너뜀
-                    continue;
-                }
-
-                RealNewsDto realNewsDto = MakeRealNewsFromInf(naverMetaData, newsDetailData);
-
-                // 중복된 뉴스 제목이 있는지 확인
-                if(!realNewsRepository.existsByTitle(realNewsDto.title())){
-                    realNewsDtoList.add(realNewsDto);
-                }
-
-
-                Thread.sleep(crawlingDelay);
-            }
-            // DTO → Entity 변환 후 저장
-            List<RealNews> realNewsList = convertDtosToEntities(realNewsDtoList);
-            List<RealNews> savedEntities = realNewsRepository.saveAll(realNewsList); // 저장된 결과 받기
-
-            // Entity → DTO 변환해서 반환
-            return convertEntitiesToDtos(savedEntities);
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("스레드 인터럽트 발생" );
-        }
-    }
-
-    //N건 패치
-    //예상되는 문제 : 최신순으로 하면 겹치는 부분이 많을 것 같음
-    //주요기사를 받아오는 로직이 필요할 것 같은데... 쉽지않을듯 자체적으론 힘들듯하고 우선 ai 프롬프트를 잘 만져봐야할 것 같습니다.
-    public List<NaverNewsDto> fetchNews(String query) {
-
-        try {
-            //display는 한 번에 보여줄 뉴스의 개수, sort는 정렬 기준 (date: 최신순, sim: 정확도순)
-            //일단 3건 패치하도록 해놨습니다. yml 에서 작성해서 사용하세요(10건 이상 x)
-            String url = naverUrl + query + "&display=" + newsDisplayCount + "&sort=" + newsSortOrder;
-
-            // http 요청 헤더 설정 (아래는 네이버 디폴트 형식)
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-Naver-Client-Id", clientId);
-            headers.set("X-Naver-Client-Secret", clientSecret);
-
-            // http 요청 엔티티(헤더+바디) 생성
-            // get이라 본문은 없고 헤더만 포함 -> 아래에서 string = null로 설정
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-
-            //http 요청 수행
-            ResponseEntity<String> response = restTemplate.exchange(
-                    url, HttpMethod.GET, entity, String.class, query);
-
-            if (response.getStatusCode() == HttpStatus.OK) {
-                // JsonNode: json 구조를 트리 형태로 표현. json의 중첩 구조를 탐색할 때 사용
-                // readTree(): json 문자열을 JsonNode 트리로 변환
-                ObjectMapper mapper = new ObjectMapper();
-                JsonNode items = mapper.readTree(response.getBody()).get("items");
-
-                if (items != null) {
-                    return getNewsMetaDataFromNaverApi(items);
-                }
-                return new ArrayList<>();
-            }
-            throw new RuntimeException("네이버 API 요청 실패");
-        }
-        catch (JsonProcessingException e) {
-            throw new RuntimeException("JSON 파싱 실패");
-        }
-    }
-
-    // 단건 크롤링
-    public NewsDetailDto crawlAddtionalInfo(String naverNewsUrl) {
-        try{
-            Document doc = Jsoup.connect(naverNewsUrl)
-                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")  // 브라우저인 척
-                    .get();  // GET 요청으로 HTML 가져오기 (robots.txt에 걸리지 않도록)
-
-            String content = Optional.ofNullable(doc.selectFirst("article#dic_area"))
-                    .map(Element::text)
-                    .orElse("");
-            String imgUrl = Optional.ofNullable(doc.selectFirst("#img1"))
-                    .map(element -> element.attr("data-src"))
-                    .orElse("");
-
-            String journalist = Optional.ofNullable(doc.selectFirst("em.media_end_head_journalist_name"))
-                    .map(Element::text)
-                    .orElse("");
-            String mediaName = Optional.ofNullable(doc.selectFirst("img.media_end_head_top_logo_img"))
-                    .map(elem -> elem.attr("alt"))
-                    .orElse("");
-
-            // 크롤링한 정보가 비어있으면 null 반환
-            if(content.isEmpty() || imgUrl.isEmpty() || journalist.isEmpty() || mediaName.isEmpty()) {
-                return null;
-            }
-
-            return NewsDetailDto.of(content, imgUrl, journalist, mediaName);
-
-        } catch (IOException e) {
-            //  Jsoup 연결 실패 시
-            throw new RuntimeException("크롤링 실패");
-        }
-    }
-
-    // 네이버 api에서 받아온 정보와 크롤링한 상세 정보를 바탕으로 RealNewsDto 생성
-    public RealNewsDto MakeRealNewsFromInf(NaverNewsDto naverNewsDto, NewsDetailDto newsDetailDto) {
-        return RealNewsDto.of(
-                naverNewsDto.title(),
-                newsDetailDto.content(),
-                naverNewsDto.description(),
-                naverNewsDto.link(),
-                newsDetailDto.imgUrl(),
-                parseNaverDate(naverNewsDto.pubDate()),
-                newsDetailDto.mediaName(),
-                newsDetailDto.journalist(),
-                naverNewsDto.originallink(),
-                NewsCategory.NOT_FILTERED
-
-        );
-    }
-
-    // fetchNews 메서드로 네이버 API에서 뉴스 목록을 가져오고
-    // 링크 정보를 바탕으로 상세 정보를 crawlAddtionalInfo 메서드로 크롤링하여 RealNews 객체를 생성
-    private List<NaverNewsDto> getNewsMetaDataFromNaverApi(JsonNode items){
-        List<NaverNewsDto> newsMetaDataList = new ArrayList<>();
-
-        for (JsonNode item : items) {
-            String rawTitle = item.get("title").asText("");
-            String originallink = item.get("originallink").asText("");
-            String link = item.get("link").asText("");
-            String rawDdscription = item.get("description").asText("");
-            String pubDate = item.get("pubDate").asText("");
-
-            String cleanedTitle = HtmlEntityDecoder.decode(rawTitle); // HTML 태그 제거
-            String cleanDescription = HtmlEntityDecoder.decode(rawDdscription); // HTML 태그 제거
-
-            //한 필드라도 비어있으면 건너뜀
-            if(cleanedTitle.isEmpty()|| originallink.isEmpty() || link.isEmpty() || cleanDescription.isEmpty() || pubDate.isEmpty())
-                continue;
-            //팩토리 메서드 사용
-            NaverNewsDto newsDto = NaverNewsDto.of(cleanedTitle, originallink, link, cleanDescription, pubDate);
-            newsMetaDataList.add(newsDto);
-        }
-
-        return newsMetaDataList;
-    }
-
-    // 네이버 API에서 받아온 날짜 문자열을 LocalDateTime으로 변환
-    private LocalDateTime parseNaverDate(String naverDate) {
-        try {
-            String dateTimeFormat = HtmlEntityDecoder.decode(naverDate);
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm", Locale.ENGLISH);
-            return LocalDateTime.parse(dateTimeFormat , formatter);
-        } catch (Exception e) {
-            return LocalDateTime.now(); // 파싱 실패 시 현재 시간
-        }
-    }
-
-    private List<RealNews> convertDtosToEntities(List<RealNewsDto> realNewsDtoList) {
-        return realNewsDtoList.stream()
-                .map(this::convertDtoToEntity)
-                .collect(Collectors.toList());
-    }
-
-    private RealNews convertDtoToEntity(RealNewsDto realNewsDto) {
-        return new RealNews(
-                realNewsDto.title(),
-                realNewsDto.content(),
-                realNewsDto.description(),
-                realNewsDto.link(),
-                realNewsDto.imgUrl(),
-                realNewsDto.originCreatedDate(),
-                realNewsDto.mediaName(),
-                realNewsDto.journalist(),
-                realNewsDto.originalNewsUrl(),
-                realNewsDto.newsCategory()
-        );
-    }
-
-    private List<RealNewsDto> convertEntitiesToDtos(List<RealNews> realNewsList) {
-        return realNewsList.stream()
-                .map(this::convertEntityToDto)
-                .collect(Collectors.toList());
-    }
-
-    private RealNewsDto convertEntityToDto(RealNews realNews) {
-        return RealNewsDto.of(
-                realNews.getTitle(),
-                realNews.getContent(),
-                realNews.getDescription(),
-                realNews.getLink(),
-                realNews.getImgUrl(),
-                realNews.getOriginCreatedDate(),
-                realNews.getMediaName(),
-                realNews.getJournalist(),
-                realNews.getOriginalNewsUrl(),
-                realNews.getNewsCategory()
-        );
-    }
+    private final RealNewsMapper realNewsMapper;
 
     @Transactional(readOnly = true)
     public Optional<RealNewsDto> getRealNewsDtoById(Long id) {
         return realNewsRepository.findById(id)
-                .map(this::convertEntityToDto);
+                .map(realNewsMapper::toDto);
     }
 
     @Transactional(readOnly = true)
     public Page<RealNewsDto> getRealNewsList(Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findAll(pageable);
-        return realNewsPage.map(this::convertEntityToDto);
+        return realNewsPage.map(realNewsMapper::toDto);
     }
 
     @Transactional(readOnly = true)
     public Page<RealNewsDto> searchRealNewsByTitle(String title, Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findByTitleContaining(title, pageable);
-        return realNewsPage.map(this::convertEntityToDto);
+        return realNewsPage.map(realNewsMapper::toDto);
     }
-
-
 }

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -299,13 +299,5 @@ public class RealNewsService {
         return realNewsPage.map(this::convertEntityToDto);
     }
 
-    @Transactional
-    public boolean deleteRealNews(Long id) {
-        if(!realNewsRepository.existsById(id)) {
-            return false;
-        }
 
-        realNewsRepository.deleteById(id);
-        return true;
-    }
 }

--- a/src/main/java/com/back/global/appconfig/AppConfig.java
+++ b/src/main/java/com/back/global/appconfig/AppConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -11,5 +12,10 @@ public class AppConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -30,6 +30,12 @@ public class SecurityConfig {
                                 .requestMatchers("/favicon.ico").permitAll()
                                 .requestMatchers("/h2-console/**").permitAll()
 
+                                .requestMatchers(HttpMethod.GET, "/api/admin/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/admin/**").permitAll()
+                                .requestMatchers(HttpMethod.DELETE, "/api/admin/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/real-news/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/real-news/**").permitAll()
+                                .requestMatchers(HttpMethod.DELETE, "/api/real-news/**").permitAll()
                                 //모두 접근 가능한 API
                                 .requestMatchers(HttpMethod.GET,  "/메인페이지/뉴스목록", "/뉴스상세페이지", "/오늘의뉴스페이지", "/ox퀴즈페이지").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/members/login", "/api/members/join").permitAll()

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -33,9 +33,9 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/admin/**").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/admin/**").permitAll()
                                 .requestMatchers(HttpMethod.DELETE, "/api/admin/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/real-news/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/real-news/**").permitAll()
-                                .requestMatchers(HttpMethod.DELETE, "/api/real-news/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/news/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/news/**").permitAll()
+                                .requestMatchers(HttpMethod.DELETE, "/api/news/**").permitAll()
                                 //모두 접근 가능한 API
                                 .requestMatchers(HttpMethod.GET,  "/메인페이지/뉴스목록", "/뉴스상세페이지", "/오늘의뉴스페이지", "/ox퀴즈페이지").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/members/login", "/api/members/join").permitAll()

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -30,12 +30,6 @@ public class SecurityConfig {
                                 .requestMatchers("/favicon.ico").permitAll()
                                 .requestMatchers("/h2-console/**").permitAll()
 
-                                .requestMatchers(HttpMethod.GET, "/api/admin/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/admin/**").permitAll()
-                                .requestMatchers(HttpMethod.DELETE, "/api/admin/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/news/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/news/**").permitAll()
-                                .requestMatchers(HttpMethod.DELETE, "/api/news/**").permitAll()
                                 //모두 접근 가능한 API
                                 .requestMatchers(HttpMethod.GET,  "/메인페이지/뉴스목록", "/뉴스상세페이지", "/오늘의뉴스페이지", "/ox퀴즈페이지").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/members/login", "/api/members/join").permitAll()


### PR DESCRIPTION
## 📢 기능 설명

- 생성, 삭제, 오늘의 뉴스 설정을 AdminNewsController로 넘김
- 사용자 컨트롤러에는 단순 조회 기능만 남김
- 오늘의 뉴스 설정
## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #85
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자 전용 뉴스 관리 기능이 추가되었습니다. (뉴스 생성, 삭제, 오늘의 뉴스 지정 등)
  * 오늘의 뉴스를 관리하는 저장소가 추가되었습니다.
  * 뉴스 데이터 매핑 기능이 도입되었습니다.

* **변경 사항**
  * 일반 뉴스 API 엔드포인트가 변경되고, 일부 생성/삭제 기능이 관리자 전용으로 이동되었습니다.
  * 뉴스 카테고리 파싱 시 기본값이 변경되었습니다.
  * RestTemplate 빈이 추가되었습니다.

* **버그 수정**
  * 뉴스 ID 유효성 검사 및 상세 에러 메시지가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->