### PR TITLE
[feat] 팩트 체크 퀴즈 조회 api 구현

### DIFF
--- a/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
@@ -3,6 +3,7 @@ package com.back.domain.news.fake.entity;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.fact.entity.FactQuiz;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.List;
 import static jakarta.persistence.CascadeType.ALL;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class FakeNews {
     @Id

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -8,17 +8,13 @@ import com.back.domain.quiz.fact.service.FactQuizService;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/quiz/fact")
 public class FactQuizController {

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -1,0 +1,66 @@
+package com.back.domain.quiz.fact.controller;
+
+import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.quiz.fact.dto.FactQuizDto;
+import com.back.domain.quiz.fact.dto.FactQuizDtoWithNewsContent;
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import com.back.domain.quiz.fact.service.FactQuizService;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz/fact")
+public class FactQuizController {
+    private final FactQuizService factQuizService;
+
+    @Operation(summary = "팩트 퀴즈 전체 조회", description = "팩트 퀴즈 목록을 조회합니다.")
+    @GetMapping
+    public RsData<List<FactQuizDto>> getFactQuizzes() {
+        List<FactQuiz> factQuizzes = factQuizService.findAll();
+
+        return new RsData<>(
+                200,
+                "팩트 퀴즈 목록 조회 성공",
+                factQuizzes.stream()
+                        .map(FactQuizDto::new)
+                        .collect(toList())
+        );
+    }
+
+    @Operation(summary = "팩트 퀴즈 카테고리별 조회", description = "카테고리별로 팩트 퀴즈 목록을 조회합니다.")
+    @GetMapping("/category")
+    public RsData<List<FactQuizDto>> getFactQuizzesByCategory(@RequestParam NewsCategory category) {
+        List<FactQuiz> factQuizzes = factQuizService.findByCategory(category);
+
+        return new RsData<>(
+                200,
+                "팩트 퀴즈 목록 조회 성공",
+                factQuizzes.stream()
+                        .map(FactQuizDto::new)
+                        .collect(toList())
+        );
+    }
+
+    @Operation(summary = "팩트 퀴즈 단건 조회", description = "팩트 퀴즈 ID로 팩트 퀴즈를 조회합니다.")
+    @GetMapping("/{id}")
+    public RsData<FactQuizDtoWithNewsContent> getFactQuizById(@PathVariable Long id) {
+        FactQuiz factQuiz = factQuizService.findById(id);
+
+        return new RsData<>(
+                200,
+                "팩트 퀴즈 조회 성공",
+                new FactQuizDtoWithNewsContent(factQuiz)
+        );
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDto.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDto.java
@@ -1,0 +1,19 @@
+package com.back.domain.quiz.fact.dto;
+
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FactQuizDto(
+        @NotNull Long id,
+        @NotBlank String question,
+        @NotBlank String realNewsTitle
+) {
+    public FactQuizDto(FactQuiz quiz) {
+        this(
+                quiz.getId(),
+                quiz.getQuestion(),
+                quiz.getRealNews().getTitle()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDtoWithNewsContent.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDtoWithNewsContent.java
@@ -1,0 +1,29 @@
+package com.back.domain.quiz.fact.dto;
+
+import com.back.domain.quiz.QuizType;
+import com.back.domain.quiz.fact.entity.CorrectNewsType;
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record FactQuizDtoWithNewsContent(
+        @NotNull Long id,
+        @NotBlank String question,
+        @NotBlank String realNewsTitle,
+        @NotBlank String realNewsContent,
+        @NotBlank String fakeNewsContent,
+        @NotNull CorrectNewsType correctNewsType,
+        @NotNull QuizType quizType
+        ) {
+    public FactQuizDtoWithNewsContent(FactQuiz quiz) {
+        this(
+                quiz.getId(),
+                quiz.getQuestion(),
+                quiz.getRealNews().getTitle(),
+                quiz.getRealNews().getContent(),
+                quiz.getFakeNews().getContent(),
+                quiz.getCorrectNewsType(),
+                quiz.getQuizType()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
@@ -7,15 +7,33 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FactQuizRepository extends JpaRepository<FactQuiz, Long> {
 
     // FactQuiz에서 RealNews.newsCategory 기반으로 조회 (N+1 문제 방지를 위해 JOIN FETCH 사용)
     @Query("""
-            SELECT fq
+            SELECT DISTINCT fq
             FROM FactQuiz fq
             JOIN FETCH fq.realNews rn
             WHERE rn.newsCategory = :category
             """)
     List<FactQuiz> findByCategory(@Param("category") NewsCategory category);
+
+    //
+    @Query("""
+            SELECT DISTINCT fq
+            FROM FactQuiz fq
+            JOIN FETCH fq.realNews
+            """)
+    List<FactQuiz> findAllWithNews();
+
+    @Query("""
+            SELECT DISTINCT fq
+            FROM FactQuiz fq
+            JOIN FETCH fq.realNews
+            JOIN FETCH fq.fakeNews
+            WHERE fq.id = :id
+            """)
+    Optional<FactQuiz> findByIdWithNews(@Param("id") Long id);
 }

--- a/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
@@ -1,0 +1,21 @@
+package com.back.domain.quiz.fact.repository;
+
+import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FactQuizRepository extends JpaRepository<FactQuiz, Long> {
+
+    // FactQuiz에서 RealNews.newsCategory 기반으로 조회 (N+1 문제 방지를 위해 JOIN FETCH 사용)
+    @Query("""
+            SELECT fq
+            FROM FactQuiz fq
+            JOIN FETCH fq.realNews rn
+            WHERE rn.newsCategory = :category
+            """)
+    List<FactQuiz> findByCategory(@Param("category") NewsCategory category);
+}

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -1,0 +1,29 @@
+package com.back.domain.quiz.fact.service;
+
+import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import com.back.domain.quiz.fact.repository.FactQuizRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FactQuizService {
+    private final FactQuizRepository factQuizRepository;
+
+    public List<FactQuiz> findAll() {
+        return factQuizRepository.findAll();
+    }
+
+    public List<FactQuiz> findByCategory(NewsCategory category) {
+        return factQuizRepository.findByCategory(category);
+    }
+
+    public FactQuiz findById(Long id) {
+        return factQuizRepository.findById(id)
+                .orElseThrow(() -> new ServiceException(404, "팩트 퀴즈를 찾을 수 없습니다. ID: " + id));
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -15,7 +15,7 @@ public class FactQuizService {
     private final FactQuizRepository factQuizRepository;
 
     public List<FactQuiz> findAll() {
-        return factQuizRepository.findAll();
+        return factQuizRepository.findAllWithNews();
     }
 
     public List<FactQuiz> findByCategory(NewsCategory category) {
@@ -23,7 +23,7 @@ public class FactQuizService {
     }
 
     public FactQuiz findById(Long id) {
-        return factQuizRepository.findById(id)
+        return factQuizRepository.findByIdWithNews(id)
                 .orElseThrow(() -> new ServiceException(404, "팩트 퀴즈를 찾을 수 없습니다. ID: " + id));
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
팩트 퀴즈 조회 api 구현
= 팩트 퀴즈 id 기반 단건조회
- 카테고리별 팩트 퀴즈 다건조회
- 팩트 퀴즈 전체 목록 조회

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #30 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 팩트 퀴즈 관련 API 엔드포인트가 추가되어 전체 퀴즈 조회, 카테고리별 조회, 개별 퀴즈 상세 조회가 가능합니다.
  * 퀴즈 정보를 제공하는 새로운 데이터 전송 객체(DTO)들이 도입되어, 실제 뉴스 및 가짜 뉴스의 제목과 내용 등 상세 정보를 확인할 수 있습니다.

* **버그 수정**
  * 해당 없음.

* **기타**
  * 내부 엔티티에 자동 Getter 적용으로 코드 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->