### PR TITLE
[feat] 팩트 퀴즈 생성 로직 구현

### DIFF
--- a/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
+++ b/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
@@ -43,8 +43,14 @@ public class FactQuiz {
     @NotNull
     private QuizType quizType = QuizType.FACT;
 
-
     @CreatedDate
-    private LocalDateTime createdDate; // 생성 날짜(DB에 저장된 날짜)a
+    private LocalDateTime createdDate;
+
+    public FactQuiz(String question, RealNews realNews, FakeNews fakeNews, CorrectNewsType correctNewsType) {
+        this.question = question;
+        this.realNews = realNews;
+        this.fakeNews = fakeNews;
+        this.correctNewsType = correctNewsType;
+    }
 
 }

--- a/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/fact/repository/FactQuizRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FactQuizRepository extends JpaRepository<FactQuiz, Long> {
 
@@ -36,4 +38,13 @@ public interface FactQuizRepository extends JpaRepository<FactQuiz, Long> {
             WHERE fq.id = :id
             """)
     Optional<FactQuiz> findByIdWithNews(@Param("id") Long id);
+
+    @Query("""
+                SELECT DISTINCT fq.realNews.id 
+                FROM FactQuiz fq 
+                WHERE fq.realNews.createdDate >= :start 
+                  AND fq.realNews.createdDate < :end
+            """)
+    Set<Long> findRealNewsIdsWithFactQuiz(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
 }

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizScheduledService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizScheduledService.java
@@ -1,0 +1,78 @@
+package com.back.domain.quiz.fact.service;
+
+import com.back.domain.news.fake.entity.FakeNews;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.RealNewsRepository;
+import com.back.domain.quiz.fact.entity.CorrectNewsType;
+import com.back.domain.quiz.fact.entity.FactQuiz;
+import com.back.domain.quiz.fact.repository.FactQuizRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FactQuizScheduledService {
+    private final FactQuizRepository factQuizRepository;
+    private final RealNewsRepository realNewsRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul") // 시간 추후 변경(가짜 퀴즈 생성 후)
+    public void generateFactQuizzes() {
+        LocalDateTime start = LocalDate.now().atStartOfDay(); // 오늘 00:00
+        LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay(); // 내일 00:00
+
+        // 오늘 날짜의 뉴스 조회(시간 설정은 추후 변경 가능)
+        List<RealNews> todayNews = realNewsRepository.findTodayNews(start, end);
+
+        if (todayNews.isEmpty()) {
+            log.info("오늘 날짜의 뉴스 없음. 퀴즈 생성을 건너뜁니다.");
+            return;
+        }
+
+        // 이미 퀴즈가 생성된 뉴스 ID Set 조회
+        Set<Long> alreadyQuizGeneratedIds = factQuizRepository.findRealNewsIdsWithFactQuiz(start, end);
+
+        for(RealNews real : todayNews) {
+            // 이미 퀴즈가 생성된 뉴스는 건너뜁니다.
+            if (alreadyQuizGeneratedIds.contains(real.getId())) {
+                log.info("이미 퀴즈가 생성된 뉴스: {}. {}", real.getId(), real.getTitle());
+                continue;
+            }
+
+            FakeNews fake = real.getFakeNews();
+
+            // 가짜 뉴스가 없는 경우 건너뜁니다.
+            if (fake == null) {
+                log.info("가짜 뉴스가 없는 뉴스: {}. {}", real.getId(), real.getTitle());
+                continue;
+            }
+
+            // 퀴즈 질문과 정답은 랜덤으로 생성
+            CorrectNewsType answerType = ThreadLocalRandom.current().nextBoolean()
+                    ? CorrectNewsType.REAL
+                    : CorrectNewsType.FAKE;
+
+            String question = answerType == CorrectNewsType.REAL
+                    ? "다음 중 진짜 뉴스는?"
+                    : "다음 중 가짜 뉴스는?";
+
+            // 팩트 퀴즈 생성 및 저장
+            FactQuiz quiz = new FactQuiz(question, real, fake, answerType);
+            //real.getFactQuizzes().add(quiz);
+            //fake.getFactQuizzes().add(quiz);
+            factQuizRepository.save(quiz);
+
+            log.info("팩트 퀴즈 생성 완료. 퀴즈 ID: {}, 뉴스 ID: {}", quiz.getId(), real.getId());
+        }
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizScheduledService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizScheduledService.java
@@ -3,20 +3,16 @@ package com.back.domain.quiz.fact.service;
 import com.back.domain.news.fake.entity.FakeNews;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.repository.RealNewsRepository;
-import com.back.domain.quiz.fact.entity.CorrectNewsType;
-import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.repository.FactQuizRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -24,55 +20,58 @@ import java.util.concurrent.ThreadLocalRandom;
 public class FactQuizScheduledService {
     private final FactQuizRepository factQuizRepository;
     private final RealNewsRepository realNewsRepository;
+    private final FactQuizService factQuizService;
 
-    @Transactional
     @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul") // 시간 추후 변경(가짜 퀴즈 생성 후)
     public void generateFactQuizzes() {
-        LocalDateTime start = LocalDate.now().atStartOfDay(); // 오늘 00:00
-        LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay(); // 내일 00:00
+        try {
+            LocalDateTime start = LocalDate.now().atStartOfDay(); // 오늘 00:00
+            LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay(); // 내일 00:00
 
-        // 오늘 날짜의 뉴스 조회(시간 설정은 추후 변경 가능)
-        List<RealNews> todayNews = realNewsRepository.findTodayNews(start, end);
+            // 오늘 날짜의 뉴스 조회(시간 설정은 추후 변경 가능)
+            List<RealNews> todayNews = realNewsRepository.findTodayNews(start, end);
 
-        if (todayNews.isEmpty()) {
-            log.info("오늘 날짜의 뉴스 없음. 퀴즈 생성을 건너뜁니다.");
-            return;
-        }
-
-        // 이미 퀴즈가 생성된 뉴스 ID Set 조회
-        Set<Long> alreadyQuizGeneratedIds = factQuizRepository.findRealNewsIdsWithFactQuiz(start, end);
-
-        for(RealNews real : todayNews) {
-            // 이미 퀴즈가 생성된 뉴스는 건너뜁니다.
-            if (alreadyQuizGeneratedIds.contains(real.getId())) {
-                log.info("이미 퀴즈가 생성된 뉴스: {}. {}", real.getId(), real.getTitle());
-                continue;
+            if (todayNews.isEmpty()) {
+                log.info("오늘 날짜의 뉴스 없음. 퀴즈 생성을 건너뜁니다.");
+                return;
             }
 
-            FakeNews fake = real.getFakeNews();
+            // 이미 퀴즈가 생성된 뉴스 ID Set 조회
+            Set<Long> alreadyQuizGeneratedIds = factQuizRepository.findRealNewsIdsWithFactQuiz(start, end);
 
-            // 가짜 뉴스가 없는 경우 건너뜁니다.
-            if (fake == null) {
-                log.info("가짜 뉴스가 없는 뉴스: {}. {}", real.getId(), real.getTitle());
-                continue;
+            int successCount = 0;
+            int failureCount = 0;
+
+            for(RealNews real : todayNews) {
+                try {
+                    // 이미 퀴즈가 생성된 뉴스는 건너뜁니다.
+                    if (alreadyQuizGeneratedIds.contains(real.getId())) {
+                        log.debug("이미 퀴즈가 생성된 뉴스: {}. {}", real.getId(), real.getTitle());
+                        continue;
+                    }
+
+                    FakeNews fake = real.getFakeNews();
+
+                    // 가짜 뉴스가 없는 경우 건너뜁니다.
+                    if (fake == null) {
+                        log.warn("가짜 뉴스가 없는 뉴스: {}. {}", real.getId(), real.getTitle());
+                        continue;
+                    }
+
+                    // 개별 트랜잭션으로 퀴즈 생성
+                    factQuizService.create(real, fake);
+                    successCount++;
+
+                } catch (Exception e) {
+                    failureCount++;
+                    log.error("팩트 퀴즈 생성 실패. 뉴스 ID: {}, 에러: {}", real.getId(), e.getMessage(), e);
+                }
             }
 
-            // 퀴즈 질문과 정답은 랜덤으로 생성
-            CorrectNewsType answerType = ThreadLocalRandom.current().nextBoolean()
-                    ? CorrectNewsType.REAL
-                    : CorrectNewsType.FAKE;
+            log.info("팩트 퀴즈 생성 배치 완료. 성공: {}개, 건너뜀: {}개, 실패: {}개", successCount, todayNews.size()-successCount-failureCount, failureCount);
 
-            String question = answerType == CorrectNewsType.REAL
-                    ? "다음 중 진짜 뉴스는?"
-                    : "다음 중 가짜 뉴스는?";
-
-            // 팩트 퀴즈 생성 및 저장
-            FactQuiz quiz = new FactQuiz(question, real, fake, answerType);
-            //real.getFactQuizzes().add(quiz);
-            //fake.getFactQuizzes().add(quiz);
-            factQuizRepository.save(quiz);
-
-            log.info("팩트 퀴즈 생성 완료. 퀴즈 ID: {}, 뉴스 ID: {}", quiz.getId(), real.getId());
+        } catch (Exception e) {
+            log.error("팩트 퀴즈 생성 배치 중 예외 발생: {}", e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -1,17 +1,23 @@
 package com.back.domain.quiz.fact.service;
 
 import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.news.fake.entity.FakeNews;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.quiz.fact.entity.CorrectNewsType;
 import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.repository.FactQuizRepository;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FactQuizService {
     private final FactQuizRepository factQuizRepository;
 
@@ -29,5 +35,25 @@ public class FactQuizService {
     public FactQuiz findById(Long id) {
         return factQuizRepository.findByIdWithNews(id)
                 .orElseThrow(() -> new ServiceException(404, "팩트 퀴즈를 찾을 수 없습니다. ID: " + id));
+    }
+
+    @Transactional
+    public void create(RealNews realNews, FakeNews fakeNews) {
+        // 퀴즈 질문과 정답은 랜덤으로 생성
+        CorrectNewsType answerType = ThreadLocalRandom.current().nextBoolean()
+                ? CorrectNewsType.REAL
+                : CorrectNewsType.FAKE;
+
+        String question = answerType == CorrectNewsType.REAL
+                ? "다음 중 진짜 뉴스는?"
+                : "다음 중 가짜 뉴스는?";
+
+        // 팩트 퀴즈 생성 및 저장
+        FactQuiz quiz = new FactQuiz(question, realNews, fakeNews, answerType);
+        //real.getFactQuizzes().add(quiz);
+        //fake.getFactQuizzes().add(quiz);
+        factQuizRepository.save(quiz);
+
+        log.debug("팩트 퀴즈 생성 완료. 퀴즈 ID: {}, 뉴스 ID: {}", quiz.getId(), realNews.getId());
     }
 }

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -6,6 +6,7 @@ import com.back.domain.quiz.fact.repository.FactQuizRepository;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,14 +15,17 @@ import java.util.List;
 public class FactQuizService {
     private final FactQuizRepository factQuizRepository;
 
+    @Transactional(readOnly = true)
     public List<FactQuiz> findAll() {
         return factQuizRepository.findAllWithNews();
     }
 
+    @Transactional(readOnly = true)
     public List<FactQuiz> findByCategory(NewsCategory category) {
         return factQuizRepository.findByCategory(category);
     }
 
+    @Transactional(readOnly = true)
     public FactQuiz findById(Long id) {
         return factQuizRepository.findByIdWithNews(id)
                 .orElseThrow(() -> new ServiceException(404, "팩트 퀴즈를 찾을 수 없습니다. ID: " + id));


### PR DESCRIPTION
## 📢 기능 설명
매일 "당일" 생성된 진짜 뉴스 목록을 가져와 각 뉴스와 그와 연결된 가짜뉴스로 구성된 팩트 퀴즈를 생성
- @Scheduled로 매일 일정한 시각에 자동 처리되도록 스케줄링
- ai를 호출하지 않고, 매일 저장되는 뉴스의 개수가 많아봐야 50개일 것 같아 비동기 처리는 하지 않음 (필요하면 나중에 적용)

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #29 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매일 오전 5시에 실시간 뉴스와 가짜 뉴스를 기반으로 자동으로 퀴즈를 생성하는 기능이 추가되었습니다.
  * 퀴즈 생성 시 진짜 뉴스와 가짜 뉴스 중 정답 유형을 무작위로 설정하는 기능이 도입되었습니다.

* **버그 수정**
  * 특정 조회 서비스 메서드에 읽기 전용 트랜잭션 처리가 적용되어 데이터 일관성이 강화되었습니다.

* **기타**
  * 퀴즈 데이터 생성 및 관리 로직이 개선되어 중복 생성 방지 및 처리 과정이 안정화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->