### PR TITLE
[feat] 유저 정답지 생성 다건조회 기능 구현 #1

### DIFF
--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.member.entity;
 
 import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.domain.quiz.QuizType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
@@ -50,11 +51,21 @@ public class Member {
 
     // 유저가 푼 퀴즈 기록을 저장하는 리스트 일단 엔티티 없어서 주석
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @Builder.Default
     private List<QuizHistory> quizHistories = new ArrayList<>(); //유저가 퀴즈를 푼 기록
 
-    public void addQuizHistory(QuizHistory quizHistory) {
-        quizHistories.add(quizHistory);
-        quizHistory.setMember(this);
+    public QuizHistory addQuizHistory(Long quizId, QuizType quizType, String answer, boolean isCorrect, int gainExp) {
+        QuizHistory history = QuizHistory.builder()
+                .quizId(quizId)
+                .quizType(quizType)
+                .answer(answer)
+                .isCorrect(isCorrect)
+                .gainExp(gainExp)
+                .build();
+
+        history.setMember(this);        // 연관관계 주인 설정
+        quizHistories.add(history);     // 정답 리스트에 추가
+        return history;
     }
 
     public Member(long id, String email, String name) {

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,6 +1,6 @@
 package com.back.domain.member.member.entity;
 
-import com.back.domain.member.quizhistory.QuizHistory;
+import com.back.domain.member.quizhistory.entity.QuizHistory;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -49,8 +49,13 @@ public class Member {
     private String apiKey; // 리프레시 토큰
 
     // 유저가 푼 퀴즈 기록을 저장하는 리스트 일단 엔티티 없어서 주석
-    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<QuizHistory> quizHistories = new ArrayList<>(); //유저가 퀴즈를 푼 기록
+
+    public void addQuizHistory(QuizHistory quizHistory) {
+        quizHistories.add(quizHistory);
+        quizHistory.setMember(this);
+    }
 
     public Member(long id, String email, String name) {
         setId(id);

--- a/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
+++ b/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
@@ -15,10 +15,9 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/histories")
@@ -61,6 +60,24 @@ public class QuizHistoryController {
                 200,
                 "퀴즈 히스토리 생성 성공",
                 new QuizHistoryDto(history)
+        );
+    }
+
+    @GetMapping
+    @Operation(summary = "현재 로그인한 유저의 퀴즈 풀이 기록 다건 조회")
+    public RsData<List<QuizHistoryDto>> getListQuizHistories() {
+        Member actor = rq.getActor();
+
+        if(actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        List<QuizHistoryDto> histories = quizHistoryService.getQuizHistoriesByMember(actor);
+
+        return new RsData<>(
+                200,
+                "퀴즈 히스토리 다건 조회 성공",
+                histories
         );
     }
 

--- a/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
+++ b/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
@@ -1,0 +1,67 @@
+package com.back.domain.member.quizhistory.controller;
+
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
+import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.domain.member.quizhistory.service.QuizHistoryService;
+import com.back.domain.quiz.QuizType;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/histories")
+@RequiredArgsConstructor
+@Tag(name = "QuizHistoryController", description = "퀴즈 히스토리 API 컨트롤러")
+public class QuizHistoryController {
+
+    private final QuizHistoryService quizHistoryService;
+    private final Rq rq;
+
+    record QuizHistoryCreateReqBody(
+            @NotNull
+            Long quizId,
+            @NotNull
+            QuizType quizType,
+            @NotNull
+            String answer
+    ) {}
+
+    @PostMapping
+    @Operation(summary = "퀴즈 히스토리 생성 , 유저가 퀴즈를 풀고-> 서버에서 정답확인 + 경험치부여 -> 퀴즈 히스토리 생성 -> 클라이언트에 반환")
+    @Transactional
+    public RsData<QuizHistoryDto> createQuizHistory(@RequestBody @Valid QuizHistoryCreateReqBody reqBody){
+
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        // 퀴즈 히스토리 생성
+        QuizHistory history = quizHistoryService.createQuizHistory(
+                actor,
+                reqBody.quizId,
+                reqBody.quizType,
+                reqBody.answer
+        );
+
+        return new RsData<>(
+                200,
+                "퀴즈 히스토리 생성 성공",
+                new QuizHistoryDto(history)
+        );
+    }
+
+}

--- a/src/main/java/com/back/domain/member/quizhistory/dto/QuizHistoryDto.java
+++ b/src/main/java/com/back/domain/member/quizhistory/dto/QuizHistoryDto.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.quizhistory.dto;
 
 import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.global.exception.ServiceException;
 import lombok.Getter;
 
 @Getter
@@ -19,6 +20,13 @@ public class QuizHistoryDto {
 
 
     public QuizHistoryDto(QuizHistory quizHistory) {
+        if(quizHistory == null) {
+            throw new ServiceException(400, "퀴즈 히스토리가 존재하지 않습니다.");
+        }
+        if(quizHistory.getMember() == null) {
+            throw new ServiceException(400, "퀴즈 히스토리의 유저 정보가 존재하지 않습니다.");
+        }
+
         this.id = quizHistory.getId();
         this.quizId = quizHistory.getQuizId();
         this.quizType = quizHistory.getQuizType().name(); // Enum을 문자열로 변환

--- a/src/main/java/com/back/domain/member/quizhistory/dto/QuizHistoryDto.java
+++ b/src/main/java/com/back/domain/member/quizhistory/dto/QuizHistoryDto.java
@@ -1,0 +1,35 @@
+package com.back.domain.member.quizhistory.dto;
+
+import com.back.domain.member.quizhistory.entity.QuizHistory;
+import lombok.Getter;
+
+@Getter
+public class QuizHistoryDto {
+
+    private long id; // 퀴즈 히스토리 ID
+    private long quizId; // 퀴즈 ID
+    private String quizType; // 퀴즈 타입
+    private String createdDate; // 퀴즈 풀이 시간
+    private String answer; // 유저 정답
+    private boolean isCorrect; // 퀴즈 정답 여부
+    private int gainExp; // 퀴즈 풀이로 얻은 경험치
+
+    private long memberId; // 유저 ID
+    private String memberName; // 유저 이름
+
+
+    public QuizHistoryDto(QuizHistory quizHistory) {
+        this.id = quizHistory.getId();
+        this.quizId = quizHistory.getQuizId();
+        this.quizType = quizHistory.getQuizType().name(); // Enum을 문자열로 변환
+        this.answer = quizHistory.getAnswer();
+        this.isCorrect = quizHistory.isCorrect();
+        this.gainExp = quizHistory.getGainExp();
+        this.createdDate = quizHistory.getCreatedDate().toString();
+        this.memberId = quizHistory.getMember().getId(); // 유저 ID
+        this.memberName = quizHistory.getMember().getName(); // 유저 이름
+
+    }
+
+
+}

--- a/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
+++ b/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
@@ -1,4 +1,4 @@
-package com.back.domain.member.quizhistory;
+package com.back.domain.member.quizhistory.entity;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.quiz.QuizType;

--- a/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
+++ b/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
@@ -27,6 +27,7 @@ public class QuizHistory {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @Setter
     Member member; //member_id
 
     @Column(nullable = false)

--- a/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
+++ b/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
@@ -1,7 +1,11 @@
 package com.back.domain.member.quizhistory.repository;
 
+import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
+    List<QuizHistory> findAllByMemberOrderByCreatedDateDesc(Member actor);
 }

--- a/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
+++ b/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.member.quizhistory.repository;
+
+import com.back.domain.member.quizhistory.entity.QuizHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
+}

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.quizhistory.service;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
 import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
@@ -18,6 +19,7 @@ import java.util.List;
 public class QuizHistoryService {
 
     private final QuizHistoryRepository quizHistoryRepository;
+    private final MemberRepository memberRepository;
 
     // detail, fact, daily 퀴즈 도메인별
     private final DetailQuizRepository detailQuizRepository;
@@ -55,10 +57,11 @@ public class QuizHistoryService {
                 .answer(answer)
                 .isCorrect(isCorrect)
                 .gainExp(gainExp)
-                .member(actor)
                 .build();
 
-        quizHistoryRepository.save(quizHistory);
+        // 양방향 연관관계 관리 및 저장
+        actor.addQuizHistory(quizHistory);
+        memberRepository.save(actor);
 
         return quizHistory;
     }

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -1,0 +1,60 @@
+package com.back.domain.member.quizhistory.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
+import com.back.domain.quiz.QuizType;
+import com.back.domain.quiz.detail.repository.DetailQuizRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuizHistoryService {
+
+    private final QuizHistoryRepository quizHistoryRepository;
+
+    // detail, fact, daily 퀴즈 도메인별
+    private final DetailQuizRepository detailQuizRepository;
+    //private final FactQuizRepository factQuizRepository;
+    //private final DailyQuizRepository dailyQuizRepository;
+
+
+    public QuizHistory createQuizHistory(Member actor, Long quizId, QuizType quizType, String answer) {
+
+        // 퀴즈 정답 가져오기
+        String correctAnswer =
+                switch (quizType) {
+                    case DETAIL -> detailQuizRepository.findById(quizId)
+                            .orElseThrow(() -> new ServiceException(400, "존재하지 않는 퀴즈입니다."))
+                            .getCorrectAnswerText();
+                    //case FACT -> factQuizRepository.findById(quizId).orElseThrow(() -> new ServiceException(400,"존재하지 않는 퀴즈입니다.")).getCorrectAnswerText();
+                    //case DAILY -> dailyQuizRepository.findById(quizId).orElseThrow(() -> new ServiceException(400,"존재하지 않는 퀴즈입니다.")).getCorrectAnswerText();
+
+                    default -> throw new ServiceException(400, "지원하지 않는 퀴즈 타입입니다.");
+                };
+
+
+        // equals로 하면 안될거같고, contains로 해야할듯
+        boolean isCorrect = correctAnswer.contains(answer);
+        int gainExp = isCorrect ? 100 : 0; // 정답일 경우 경험치 100점 부여
+
+        //경험치 적용
+        actor.setExp(actor.getExp() + gainExp);
+
+        // 퀴즈 히스토리 생성
+        QuizHistory quizHistory = QuizHistory.builder()
+                .quizId(quizId)
+                .quizType(quizType)
+                .answer(answer)
+                .isCorrect(isCorrect)
+                .gainExp(gainExp)
+                .member(actor)
+                .build();
+
+        quizHistoryRepository.save(quizHistory);
+
+        return quizHistory;
+    }
+}

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.quizhistory.service;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
 import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
 import com.back.domain.quiz.QuizType;
@@ -8,6 +9,8 @@ import com.back.domain.quiz.detail.repository.DetailQuizRepository;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -56,5 +59,13 @@ public class QuizHistoryService {
         quizHistoryRepository.save(quizHistory);
 
         return quizHistory;
+    }
+
+    public List<QuizHistoryDto> getQuizHistoriesByMember(Member actor) {
+        List<QuizHistory> quizHistories = quizHistoryRepository.findAllByMemberOrderByCreatedDateDesc(actor); //푼 시간을 기준으로 내림차순 정렬(최신 풀이부터)
+
+        return quizHistories.stream()
+                .map(QuizHistoryDto::new)
+                .toList();
     }
 }

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -9,6 +9,7 @@ import com.back.domain.quiz.detail.repository.DetailQuizRepository;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class QuizHistoryService {
     //private final DailyQuizRepository dailyQuizRepository;
 
 
+    @Transactional
     public QuizHistory createQuizHistory(Member actor, Long quizId, QuizType quizType, String answer) {
 
         // 퀴즈 정답 가져오기


### PR DESCRIPTION
## 📢 기능 설명
유저가 문제를 풀면 정답지 생성 (서버에서 맞는지 체크  경험치 증가)
유저가 푼 문제들을 다건조회 할수있는 기능 구현

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #74 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 퀴즈 히스토리 생성 및 조회 API가 추가되었습니다. 사용자는 자신의 퀴즈 풀이 기록을 생성하고 확인할 수 있습니다.
  * 퀴즈 히스토리 정보를 제공하는 데이터 전송 객체(DTO)가 도입되었습니다.
  * 퀴즈 히스토리 관련 서비스가 추가되어 정답 검증 및 경험치 부여 기능을 제공합니다.
  * 퀴즈 히스토리 저장소가 추가되어 회원별 퀴즈 기록을 최신순으로 조회할 수 있습니다.
  * 회원 엔티티에 퀴즈 히스토리 추가 기능이 포함되어 퀴즈 기록 관리가 개선되었습니다.

* **버그 수정**
  * 일부 클래스의 패키지 경로가 정정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->