### PR TITLE
[feat] 팩트 퀴즈 삭제 api 구현

### DIFF
--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -41,7 +41,7 @@ public class FactQuizController {
 
         return new RsData<>(
                 200,
-                "팩트 퀴즈 목록 조회 성공",
+                "팩트 퀴즈 목록 조회 성공. 카테고리: " + category,
                 factQuizzes.stream()
                         .map(FactQuizDto::new)
                         .collect(toList())
@@ -55,8 +55,17 @@ public class FactQuizController {
 
         return new RsData<>(
                 200,
-                "팩트 퀴즈 조회 성공",
+                "팩트 퀴즈 조회 성공. ID: " + id,
                 new FactQuizDtoWithNewsContent(factQuiz)
         );
+    }
+
+    @Operation(summary = "팩트 퀴즈 삭제", description = "팩트 퀴즈 ID로 팩트 퀴즈를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public RsData<Void> deleteFactQuiz(@PathVariable Long id) {
+        factQuizService.delete(id);
+        return RsData.of(
+                200,
+                "팩트 퀴즈 삭제 성공. ID: " + id);
     }
 }

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -56,4 +56,12 @@ public class FactQuizService {
 
         log.debug("팩트 퀴즈 생성 완료. 퀴즈 ID: {}, 뉴스 ID: {}", quiz.getId(), realNews.getId());
     }
+
+    @Transactional
+    public void delete(Long id) {
+        FactQuiz quiz = factQuizRepository.findById(id)
+                .orElseThrow(() -> new ServiceException(404, "팩트 퀴즈를 찾을 수 없습니다. ID: " + id));
+
+        factQuizRepository.delete(quiz);
+    }
 }


### PR DESCRIPTION
## 📢 기능 설명
팩트 퀴즈 삭제 api 구현
- 팩트 퀴즈 id로 해당 퀴즈를 조회 후 삭제합니다.

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #31 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 퀴즈 ID로 사실 퀴즈를 삭제할 수 있는 기능이 추가되었습니다.

* **개선 사항**
  * 카테고리별 및 ID별 사실 퀴즈 조회 시, 성공 메시지에 카테고리와 ID 정보가 포함되어 안내가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->