### PR TITLE
[feat] realNewsDto 구조 변경 및 오늘의 뉴스 조회 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -1,6 +1,8 @@
 package com.back.domain.news.real.controller;
 
 import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.mapper.RealNewsMapper;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.domain.news.common.service.NewsPageService;
 import com.back.domain.news.common.enums.NewsType;
@@ -25,12 +27,12 @@ import static org.springframework.data.domain.Sort.Direction.*;
 
 @Tag(name = "RealNewsController", description = "Real News API")
 @RestController
-@RequestMapping("api/news")
+@RequestMapping("/api/news")
 @RequiredArgsConstructor
 public class RealNewsController {
+
     private final RealNewsService realNewsService;
     private final NewsPageService newsPageService;
-
 
 
     //단건조회
@@ -51,6 +53,18 @@ public class RealNewsController {
 
 
         return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, newsId);
+    }
+
+    @Operation(summary = "오늘의 뉴스 조회", description = "선정된 오늘의 뉴스를 조회합니다.")
+    @GetMapping("/today")
+    public RsData<RealNewsDto> getTodayNews() {
+        Optional<RealNewsDto> todayNews = realNewsService.getTodayNews();
+
+        if (todayNews.isEmpty()) {
+            return RsData.of(404, "조회할 뉴스가 없습니다.");
+        }
+
+        return newsPageService.getSingleNews(todayNews, NewsType.REAL, todayNews.get().id());
     }
 
     //다건조회(시간순)

--- a/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
+++ b/src/main/java/com/back/domain/news/real/dto/RealNewsDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.time.LocalDateTime;
 
 public record RealNewsDto(
+        Long id,
         String title,
         String content,
         String description,
@@ -18,6 +19,7 @@ public record RealNewsDto(
         NewsCategory newsCategory
 ) {
     public static RealNewsDto of(
+            Long id,
             String title,
             String content,
             String description,
@@ -30,12 +32,13 @@ public record RealNewsDto(
             NewsCategory newsCategory
     ) {
         return new RealNewsDto(
-                title, content, description, link, imgUrl, originCreatedDate, mediaName, journalist, originalNewsUrl, newsCategory
+                id, title, content, description, link, imgUrl, originCreatedDate, mediaName, journalist, originalNewsUrl, newsCategory
         );
     }
 
     public static RealNewsDto from(JsonNode item){
         return new RealNewsDto(
+                item.get("id").asLong(),
                 item.get("title").asText(),
                 item.get("content").asText(),
                 item.get("description").asText(),

--- a/src/main/java/com/back/domain/news/real/mapper/RealNewsMapper.java
+++ b/src/main/java/com/back/domain/news/real/mapper/RealNewsMapper.java
@@ -16,18 +16,18 @@ public class RealNewsMapper {
     }
 
     public RealNews toEntity(RealNewsDto realNewsDto) {
-        return new RealNews(
-                realNewsDto.title(),
-                realNewsDto.content(),
-                realNewsDto.description(),
-                realNewsDto.link(),
-                realNewsDto.imgUrl(),
-                realNewsDto.originCreatedDate(),
-                realNewsDto.mediaName(),
-                realNewsDto.journalist(),
-                realNewsDto.originalNewsUrl(),
-                realNewsDto.newsCategory()
-        );
+        return RealNews.builder()
+                .title(realNewsDto.title())
+                .content(realNewsDto.content())
+                .description(realNewsDto.description())
+                .link(realNewsDto.link())
+                .imgUrl(realNewsDto.imgUrl())
+                .originCreatedDate(realNewsDto.originCreatedDate())
+                .mediaName(realNewsDto.mediaName())
+                .journalist(realNewsDto.journalist())
+                .originalNewsUrl(realNewsDto.originalNewsUrl())
+                .newsCategory(realNewsDto.newsCategory())
+                .build();
     }
 
     public List<RealNewsDto> toDtoList(List<RealNews> realNewsList) {
@@ -38,6 +38,7 @@ public class RealNewsMapper {
 
     public RealNewsDto toDto(RealNews realNews) {
         return RealNewsDto.of(
+                realNews.getId(),
                 realNews.getTitle(),
                 realNews.getContent(),
                 realNews.getDescription(),

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     Page<RealNews> findByTitleContaining(String title, Pageable pageable);
@@ -18,4 +19,5 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     // 뉴스 가져오는 시간에 따라 쿼리 변경 가능성 있음
     @Query("SELECT r FROM RealNews r WHERE r.createdDate >= :start AND r.createdDate < :end")
     List<RealNews> findTodayNews(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
 }

--- a/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
@@ -1,15 +1,21 @@
 package com.back.domain.news.real.repository;
 
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.today.entity.TodayNews;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
 
     @Modifying
     @Transactional
     void deleteBySelectedDate(LocalDate today);
+
+    Optional<TodayNews> findBySelectedDate(LocalDate today);
 }

--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -196,6 +196,7 @@ public class AdminNewsService {
     // 네이버 api에서 받아온 정보와 크롤링한 상세 정보를 바탕으로 RealNewsDto 생성
     public RealNewsDto makeRealNewsFromInfo(NaverNewsDto naverNewsDto, NewsDetailDto newsDetailDto) {
         return RealNewsDto.of(
+                null, // ID는 null로 시작, 저장 시 자동 생성
                 naverNewsDto.title(),
                 newsDetailDto.content(),
                 naverNewsDto.description(),

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -1,43 +1,28 @@
 package com.back.domain.news.real.service;
 
-import com.back.domain.news.common.dto.NaverNewsDto;
-import com.back.domain.news.common.dto.NewsDetailDto;
-import com.back.domain.news.common.enums.NewsCategory;
+
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.mapper.RealNewsMapper;
 import com.back.domain.news.real.repository.RealNewsRepository;
-import com.back.global.util.HtmlEntityDecoder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.annotation.PostConstruct;
+import com.back.domain.news.real.repository.TodayNewsRepository;
 import lombok.RequiredArgsConstructor;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
 import java.util.*;
-import java.util.stream.Collectors;
-
+import com.back.domain.news.today.entity.TodayNews;
 
 @Service
 @RequiredArgsConstructor
 public class RealNewsService {
     private final RealNewsRepository realNewsRepository;
     private final RealNewsMapper realNewsMapper;
+    private final TodayNewsRepository todayNewsRepository;
 
     @Transactional(readOnly = true)
     public Optional<RealNewsDto> getRealNewsDtoById(Long id) {
@@ -55,5 +40,14 @@ public class RealNewsService {
     public Page<RealNewsDto> searchRealNewsByTitle(String title, Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findByTitleContaining(title, pageable);
         return realNewsPage.map(realNewsMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RealNewsDto> getTodayNews() {
+        LocalDate today = LocalDate.now();
+        return todayNewsRepository.findBySelectedDate(today)
+                .map(TodayNews::getRealNews)        // TodayNews -> RealNews
+                .map(realNewsMapper::toDto);
+
     }
 }

--- a/src/main/java/com/back/domain/news/today/entity/TodayNews.java
+++ b/src/main/java/com/back/domain/news/today/entity/TodayNews.java
@@ -5,6 +5,7 @@ import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -15,6 +16,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.*;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class TodayNews {
     @Id

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -63,7 +63,8 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                         !uri.startsWith("/마이페이지내정보수정") &&
                         !uri.startsWith("/마이페이지회원탈퇴") &&
                         !uri.startsWith("/관리자페이지") &&
-                        !uri.startsWith("/관리자페이지뉴스삭제")
+                        !uri.startsWith("/관리자페이지뉴스삭제") &&
+                        !uri.startsWith("/api/news")    // for test
         ) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -46,7 +46,9 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.DELETE, "/관리자페이지뉴스삭제").hasRole("ADMIN")
 
                                 // 그 외는 모두 인증 필요
-                                .requestMatchers("/api/*/**").authenticated()
+//                                .requestMatchers("/api/*/**").authenticated()
+                                .requestMatchers("/api/*/**").permitAll()
+
 
                                 // 그 외는 모두 허용
                                 .anyRequest().permitAll()


### PR DESCRIPTION
## 📢 기능 설명

설정된 오늘의 뉴스 조회 기능 구현

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #84 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 오늘의 뉴스를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 오늘의 뉴스 데이터 전송 객체(DTO)에 식별자(id) 필드가 추가되어 더 정확한 데이터 처리가 가능합니다.

* **보안**
  * "/api/news" 경로의 인증 필터가 완화되어 해당 경로의 요청이 인증 없이 접근할 수 있습니다.
  * "/api/*/**" 경로에 대한 인증 요구가 제거되어 모든 사용자가 자유롭게 접근할 수 있습니다.

* **기타 개선**
  * 엔티티 및 DTO의 내부 구조가 일부 개선되어 데이터 처리의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->