### PR TITLE
[feat] 오늘의 퀴즈 조회 api 구현#1

### DIFF
--- a/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
+++ b/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
@@ -1,0 +1,32 @@
+package com.back.domain.quiz.daily.controller;
+
+import com.back.domain.quiz.daily.dto.DailyQuizDto;
+import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.back.domain.quiz.daily.service.DailyQuizService;
+import com.back.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/quiz/daily")
+@RequiredArgsConstructor
+public class DailyQuizController {
+    private final DailyQuizService dailyQuizService;
+
+    @GetMapping("/{todayNewsId}")
+    public RsData<List<DailyQuizDto>> getDailyQuizzes(@PathVariable Long todayNewsId) {
+        List<DailyQuiz> dailyQuizzes = dailyQuizService.getDailyQuizzes(todayNewsId);
+        return RsData.of(
+                200,
+                "오늘의 퀴즈 조회 성공",
+                dailyQuizzes.stream()
+                        .map(DailyQuizDto::new)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizDto.java
+++ b/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizDto.java
@@ -1,0 +1,24 @@
+package com.back.domain.quiz.daily.dto;
+
+import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.back.domain.quiz.detail.entity.Option;
+
+public record DailyQuizDto(
+        Long id,
+        String question,
+        String option1,
+        String option2,
+        String option3,
+        Option correctOption
+) {
+    public DailyQuizDto(DailyQuiz quiz){
+        this(
+                quiz.getId(),
+                quiz.getDetailQuiz().getQuestion(),
+                quiz.getDetailQuiz().getOption1(),
+                quiz.getDetailQuiz().getOption2(),
+                quiz.getDetailQuiz().getOption3(),
+                quiz.getDetailQuiz().getCorrectOption()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
@@ -1,0 +1,18 @@
+package com.back.domain.quiz.daily.repository;
+
+import com.back.domain.quiz.daily.entity.DailyQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DailyQuizRepository extends JpaRepository<DailyQuiz, Long> {
+    @Query("""
+            SELECT dq 
+            FROM DailyQuiz dq
+            JOIN FETCH dq.detailQuiz 
+            WHERE dq.todayNews.id = :todayNewsId
+            """)
+    List<DailyQuiz> findByTodayNewsId(@Param("todayNewsId") Long todayNewsId);
+}

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -1,0 +1,20 @@
+package com.back.domain.quiz.daily.service;
+
+import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.back.domain.quiz.daily.repository.DailyQuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailyQuizService {
+    private final DailyQuizRepository dailyQuizRepository;
+
+    @Transactional(readOnly = true)
+    public List<DailyQuiz> getDailyQuizzes(Long todayNewsId) {
+        return dailyQuizRepository.findByTodayNewsId(todayNewsId);
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDto.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDto.java
@@ -1,13 +1,11 @@
 package com.back.domain.quiz.fact.dto;
 
 import com.back.domain.quiz.fact.entity.FactQuiz;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record FactQuizDto(
-        @NotNull Long id,
-        @NotBlank String question,
-        @NotBlank String realNewsTitle
+        Long id,
+        String question,
+        String realNewsTitle
 ) {
     public FactQuizDto(FactQuiz quiz) {
         this(

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDtoWithNewsContent.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizDtoWithNewsContent.java
@@ -3,17 +3,15 @@ package com.back.domain.quiz.fact.dto;
 import com.back.domain.quiz.QuizType;
 import com.back.domain.quiz.fact.entity.CorrectNewsType;
 import com.back.domain.quiz.fact.entity.FactQuiz;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record FactQuizDtoWithNewsContent(
-        @NotNull Long id,
-        @NotBlank String question,
-        @NotBlank String realNewsTitle,
-        @NotBlank String realNewsContent,
-        @NotBlank String fakeNewsContent,
-        @NotNull CorrectNewsType correctNewsType,
-        @NotNull QuizType quizType
+        Long id,
+        String question,
+        String realNewsTitle,
+        String realNewsContent,
+        String fakeNewsContent,
+        CorrectNewsType correctNewsType,
+        QuizType quizType
         ) {
     public FactQuizDtoWithNewsContent(FactQuiz quiz) {
         this(


### PR DESCRIPTION
## 📢 기능 설명
오늘의 퀴즈 조회 api 구현
- 오늘의 뉴스 id 기반 오늘의 퀴즈 목록 조회
- 반환 객체의 detailQuiz에 접근하므로 n+1 문제 방지를 위해 JOIN FETCH 사용

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #23 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 오늘의 뉴스 ID로 일일 퀴즈 목록을 조회하는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 팩트 퀴즈 관련 DTO에서 필드 유효성 검증(Validation) 어노테이션이 제거되어 입력값 제약이 완화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->