### PR TITLE
[feat] 오늘의 퀴즈 생성 로직 구현#1

### DIFF
--- a/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/TodayNewsRepository.java
@@ -1,11 +1,8 @@
 package com.back.domain.news.real.repository;
 
-import com.back.domain.news.real.dto.RealNewsDto;
-import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.today.entity.TodayNews;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -18,4 +15,6 @@ public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
     void deleteBySelectedDate(LocalDate today);
 
     Optional<TodayNews> findBySelectedDate(LocalDate today);
+
+    Optional<TodayNews> findFirstByOrderBySelectedDateDesc();
 }

--- a/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
@@ -1,7 +1,0 @@
-package com.back.domain.news.today.repository;
-
-import com.back.domain.news.today.entity.TodayNews;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
-}

--- a/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.news.today.repository;
+
+import com.back.domain.news.today.entity.TodayNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
+}

--- a/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
+++ b/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
@@ -5,10 +5,7 @@ import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.service.DailyQuizService;
 import com.back.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 

--- a/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
@@ -1,5 +1,6 @@
 package com.back.domain.quiz.daily.repository;
 
+import com.back.domain.news.today.entity.TodayNews;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,6 @@ public interface DailyQuizRepository extends JpaRepository<DailyQuiz, Long> {
             WHERE dq.todayNews.id = :todayNewsId
             """)
     List<DailyQuiz> findByTodayNewsId(@Param("todayNewsId") Long todayNewsId);
+
+    boolean existsByTodayNews(TodayNews todayNews);
 }

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -1,8 +1,15 @@
 package com.back.domain.quiz.daily.service;
 
+import com.back.domain.news.real.entity.RealNews;
+import com.back.domain.news.real.repository.TodayNewsRepository;
+import com.back.domain.news.today.entity.TodayNews;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.repository.DailyQuizRepository;
+import com.back.domain.quiz.detail.entity.DetailQuiz;
+import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,11 +17,41 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DailyQuizService {
     private final DailyQuizRepository dailyQuizRepository;
+    private final TodayNewsRepository todayNewsRepository;
 
     @Transactional(readOnly = true)
     public List<DailyQuiz> getDailyQuizzes(Long todayNewsId) {
         return dailyQuizRepository.findByTodayNewsId(todayNewsId);
+    }
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void createDailyQuiz() {
+        TodayNews todayNews = todayNewsRepository.findFirstByOrderBySelectedDateDesc()
+                .orElseThrow(() -> new ServiceException(400, "오늘의 뉴스가 없습니다."));
+
+        boolean alreadyCreated = dailyQuizRepository.existsByTodayNews(todayNews);
+
+        if (alreadyCreated) {
+            log.info("이미 오늘의 퀴즈가 생성되었습니다. 작업을 건너뜁니다.");
+            return;
+        }
+
+        RealNews realNews = todayNews.getRealNews();
+
+        List<DetailQuiz> quizzes = realNews.getDetailQuizzes();
+
+        if (quizzes == null || quizzes.isEmpty()) {
+            throw new ServiceException(400, "연결된 상세 퀴즈가 없습니다.");
+        }
+
+        for(DetailQuiz quiz : quizzes) {
+            DailyQuiz dailyQuiz = new DailyQuiz(todayNews, quiz);
+            dailyQuizRepository.save(dailyQuiz);
+        }
+
+        log.info("오늘의 퀴즈 생성 완료");
     }
 }

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -47,10 +47,11 @@ public class DailyQuizService {
             throw new ServiceException(400, "연결된 상세 퀴즈가 없습니다.");
         }
 
-        for(DetailQuiz quiz : quizzes) {
-            DailyQuiz dailyQuiz = new DailyQuiz(todayNews, quiz);
-            dailyQuizRepository.save(dailyQuiz);
-        }
+        List<DailyQuiz> dailyQuizzes = quizzes.stream()
+                .map(quiz -> new DailyQuiz(todayNews, quiz))
+                .toList();
+
+        dailyQuizRepository.saveAll(dailyQuizzes);
 
         log.info("오늘의 퀴즈 생성 완료");
     }


### PR DESCRIPTION
## 📢 기능 설명
오늘의 퀴즈 생성 로직 구현
- 매일 정해진 시각에 오늘의 뉴스 테이블에 가장 마지막에 등록된 뉴스를 기반으로 오늘의 퀴즈를 생성
- @Scheduled를 사용했고, 시간은 나중에 변경될 가능성 있음(오늘의 뉴스 등록 이후)
필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #22 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매일 오전 3시에 최신 뉴스 기반으로 일일 퀴즈가 자동 생성됩니다. 이미 생성된 경우 중복 생성을 방지합니다.
  * 최신 뉴스 정보를 조회하는 기능이 추가되었습니다.
  * 일일 퀴즈 존재 여부를 확인하는 기능이 추가되었습니다.
  * 오늘 뉴스 데이터에 대한 기본적인 데이터 저장 및 조회 기능이 제공됩니다.

* **버그 수정**
  * 불필요한 import 문이 정리되었습니다.

* **기타**
  * 일부 코드 스타일 및 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->