### PR TITLE
[chore] 퀴즈 도메인 api 문서 작성

### DIFF
--- a/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
+++ b/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
@@ -4,17 +4,41 @@ import com.back.domain.quiz.daily.dto.DailyQuizDto;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.service.DailyQuizService;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/quiz/daily")
 @RequiredArgsConstructor
+@Tag(name= "DailyQuizController", description = "오늘의 퀴즈 관련 API")
 public class DailyQuizController {
     private final DailyQuizService dailyQuizService;
 
+    @Operation(summary = "오늘의 퀴즈 조회", description = "오늘의 뉴스 ID로 오늘의 퀴즈(3개)를 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "오늘의 퀴즈 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 200, \"msg\": \"오늘의 퀴즈 조회 성공\", \"data\": [{\"id\": 1, \"question\": \"문제1\", \"option1\": \"선택지1\", \"option2\": \"선택지2\", \"option3\": \"선택지3\", \"correctOption\": \"OPTION1\"}]}"))),
+                    @ApiResponse(responseCode = "404", description = "오늘의 뉴스에 해당하는 오늘의 퀴즈가 존재하지 않음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"오늘의 뉴스에 해당하는 오늘 퀴즈가 존재하지 않습니다.\", \"data\": null}")))
+            }
+    )
     @GetMapping("/{todayNewsId}")
     public RsData<List<DailyQuizDto>> getDailyQuizzes(@PathVariable Long todayNewsId) {
         List<DailyQuiz> dailyQuizzes = dailyQuizService.getDailyQuizzes(todayNewsId);

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -24,13 +24,17 @@ public class DailyQuizService {
 
     @Transactional(readOnly = true)
     public List<DailyQuiz> getDailyQuizzes(Long todayNewsId) {
-        return dailyQuizRepository.findByTodayNewsId(todayNewsId);
+        List<DailyQuiz> quizzes = dailyQuizRepository.findByTodayNewsId(todayNewsId);
+        if( quizzes.isEmpty()) {
+            throw new ServiceException(404, "오늘의 뉴스에 해당하는 오늘 퀴즈가 존재하지 않습니다.");
+        }
+        return quizzes;
     }
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void createDailyQuiz() {
         TodayNews todayNews = todayNewsRepository.findFirstByOrderBySelectedDateDesc()
-                .orElseThrow(() -> new ServiceException(400, "오늘의 뉴스가 없습니다."));
+                .orElseThrow(() -> new ServiceException(404, "오늘의 뉴스가 없습니다."));
 
         boolean alreadyCreated = dailyQuizRepository.existsByTodayNews(todayNews);
 

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -5,6 +5,12 @@ import com.back.domain.quiz.detail.entity.DetailQuiz;
 import com.back.domain.quiz.detail.service.DetailQuizService;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -14,16 +20,24 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/quiz/detail")
+@Tag(name = "DetailQuizController", description = "상세 퀴즈 관련 API")
 public class DetailQuizController {
     private final DetailQuizService detailQuizService;
 
     // 상세 퀴즈 목록 조회(전체 조회)
     @Operation(summary = "전체 조회", description = "상세 퀴즈 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "상세 퀴즈 목록 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+            }
+    )
     @GetMapping
     public RsData<List<DetailQuizDto>> getDetailQuizzes() {
         List<DetailQuiz> detailQuizzes = detailQuizService.findAll();
 
-        return new RsData<> (
+        return new RsData<>(
                 200,
                 "상세 퀴즈 목록 조회 성공",
                 detailQuizzes.stream()
@@ -34,6 +48,17 @@ public class DetailQuizController {
 
     // 상세 퀴즈 단건 조회(퀴즈 ID로 조회)
     @Operation(summary = "단건 조회", description = "퀴즈 ID로 상세 퀴즈를 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "상세 퀴즈 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 상세 퀴즈를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 id의 상세 퀴즈가 존재하지 않습니다. id: 1\", \"data\": null}"))),
+            }
+    )
     @GetMapping("/{id}")
     public RsData<DetailQuizDto> getDetailQuiz(@PathVariable Long id) {
         DetailQuiz detailQuiz = detailQuizService.findById(id);
@@ -47,6 +72,20 @@ public class DetailQuizController {
 
     // 상세 퀴즈 다건 조회(뉴스 ID로 조회)
     @Operation(summary = "뉴스 ID 기반 다건 조회", description = "뉴스 ID로 해당 뉴스의 상세 퀴즈 목록(3개)을 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "뉴스 ID로 상세 퀴즈 목록 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 뉴스 또는 해당 뉴스의 상세 퀴즈를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = {
+                                            @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 id의 뉴스가 존재하지 않습니다. id: 1\", \"data\": null}"),
+                                            @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"\"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: id: 1\", \"data\": null}")
+                                    }))
+            }
+    )
     @GetMapping("/news/{newsId}")
     public RsData<List<DetailQuizDto>> getDetailQuizzesByNewsId(@PathVariable Long newsId) {
         List<DetailQuiz> detailQuizzes = detailQuizService.findByNewsId(newsId);
@@ -63,6 +102,21 @@ public class DetailQuizController {
 
     // 상세 퀴즈 생성(뉴스 ID로 찾은 뉴스의 퀴즈 모두 삭제 후 새로 생성해서 저장)
     @Operation(summary = "뉴스 ID 기반 상세 퀴즈 생성", description = "뉴스 ID로 해당 뉴스의 상세 퀴즈를 3개 생성합니다. 기존 퀴즈는 삭제 후 새로 생성합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "상세 퀴즈 생성 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 뉴스를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 id의 뉴스가 존재하지 않습니다. id: 1\", \"data\": null}"))),
+                    @ApiResponse(responseCode = "500", description = "AI 서비스 호출 실패",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 500, \"msg\": \"AI 서비스 호출에 실패했습니다\", \"data\": null}")))
+            }
+    )
     @PostMapping("news/{newsId}/regenerate")
     public RsData<List<DetailQuizDto>> generateDetailQuizzes(@PathVariable Long newsId) {
         List<DetailQuizDto> newQuizzes = detailQuizService.generateQuizzes(newsId);
@@ -79,7 +133,20 @@ public class DetailQuizController {
 
 
     // 상세 퀴즈 수정(퀴즈 ID로 수정) - 퀴즈 품질 관리를 위한 api
-    @Operation(summary="퀴즈 ID 기반 상세 퀴즈 수정", description = "퀴즈 ID로 상세 퀴즈를 수정합니다.")
+    @Operation(summary = "퀴즈 ID 기반 상세 퀴즈 수정", description = "퀴즈 ID로 상세 퀴즈를 수정합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "상세 퀴즈 수정 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 상세 퀴즈를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = {
+                                            @ExampleObject(name = "퀴즈 없음", value = "{\"resultCode\": 404, \"msg\": \"해당 id의 상세 퀴즈가 존재하지 않습니다. id: 1\", \"data\": null}")
+                                    }))
+            }
+    )
     @PutMapping("/{id}")
     public RsData<DetailQuizDto> updateDetailQuiz(@PathVariable Long id, @RequestBody @Valid DetailQuizDto detailQuizDto) {
         DetailQuiz updatedQuiz = detailQuizService.updateDetailQuiz(id, detailQuizDto);

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -81,7 +81,7 @@ public class DetailQuizController {
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = RsData.class),
                                     examples = {
-                                            @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"\"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: id: 1\", \"data\": null}")
+                                            @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: id: 1\", \"data\": null}")
                                     }))
             }
     )

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -81,7 +81,6 @@ public class DetailQuizController {
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = RsData.class),
                                     examples = {
-                                            @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 id의 뉴스가 존재하지 않습니다. id: 1\", \"data\": null}"),
                                             @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"\"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: id: 1\", \"data\": null}")
                                     }))
             }

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
@@ -34,19 +34,28 @@ public class DetailQuizService {
     @Transactional(readOnly = true)
     public DetailQuiz findById(Long id) {
         return detailQuizRepository.findById(id)
-                .orElseThrow(() -> new ServiceException(400, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));
+                .orElseThrow(() -> new ServiceException(404, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));
     }
 
     @Transactional(readOnly = true)
     public List<DetailQuiz> findByNewsId(Long newsId) {
-        return detailQuizRepository.findByRealNewsId(newsId);
+        RealNews news = realNewsRepository.findById(newsId)
+                .orElseThrow(() -> new ServiceException(404, "해당 id의 뉴스가 존재하지 않습니다. id: " + newsId));
+
+        List<DetailQuiz> quizzes = detailQuizRepository.findByRealNewsId(newsId);
+
+        if (quizzes.isEmpty()) {
+            throw new ServiceException(404, "해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: " + newsId);
+        }
+
+        return quizzes;
     }
 
 
     // newsId로 뉴스 조회 후 AI api 호출해 퀴즈 생성
     public List<DetailQuizDto> generateQuizzes(Long newsId) {
         RealNews news = realNewsRepository.findById(newsId)
-                .orElseThrow(() -> new ServiceException(400, "해당 id의 뉴스가 존재하지 않습니다. id: " + newsId));
+                .orElseThrow(() -> new ServiceException(404, "해당 id의 뉴스가 존재하지 않습니다. id: " + newsId));
 
         DetailQuizReqDto req = new DetailQuizReqDto(
                 news.getTitle(),
@@ -62,7 +71,7 @@ public class DetailQuizService {
     @Transactional
     public List<DetailQuiz> saveQuizzes(Long newsId, List<DetailQuizDto> quizzes) {
         RealNews news = realNewsRepository.findById(newsId)
-                .orElseThrow(() -> new ServiceException(400, "해당 id의 뉴스가 존재하지 않습니다. id: " + newsId));
+                .orElseThrow(() -> new ServiceException(404, "해당 id의 뉴스가 존재하지 않습니다. id: " + newsId));
 
         detailQuizRepository.deleteByRealNewsId(newsId); // 기존 퀴즈 삭제
 
@@ -84,7 +93,7 @@ public class DetailQuizService {
     @Transactional
     public DetailQuiz updateDetailQuiz(Long id, DetailQuizDto detailQuizDto) {
         DetailQuiz quiz = detailQuizRepository.findById(id)
-                .orElseThrow(() -> new ServiceException(400, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));
+                .orElseThrow(() -> new ServiceException(404, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));
 
         quiz.setQuestion(detailQuizDto.question());
         quiz.setOption1(detailQuizDto.option1());

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -7,6 +7,12 @@ import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.service.FactQuizService;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,10 +23,18 @@ import static java.util.stream.Collectors.toList;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/quiz/fact")
+@Tag(name= "FactQuizController", description = "팩트 퀴즈(진짜가짜 퀴즈) 관련 API")
 public class FactQuizController {
     private final FactQuizService factQuizService;
 
-    @Operation(summary = "팩트 퀴즈 전체 조회", description = "팩트 퀴즈 목록을 조회합니다.")
+    @Operation(summary = "팩트 퀴즈 전체 조회", description = "팩트 퀴즈 (전체) 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "팩트 퀴즈 (전체) 목록 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+            }
+    )
     @GetMapping
     public RsData<List<FactQuizDto>> getFactQuizzes() {
         List<FactQuiz> factQuizzes = factQuizService.findAll();
@@ -35,6 +49,13 @@ public class FactQuizController {
     }
 
     @Operation(summary = "팩트 퀴즈 카테고리별 조회", description = "카테고리별로 팩트 퀴즈 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "팩트 퀴즈 목록 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class)))
+            }
+    )
     @GetMapping("/category")
     public RsData<List<FactQuizDto>> getFactQuizzesByCategory(@RequestParam NewsCategory category) {
         List<FactQuiz> factQuizzes = factQuizService.findByCategory(category);
@@ -49,6 +70,17 @@ public class FactQuizController {
     }
 
     @Operation(summary = "팩트 퀴즈 단건 조회", description = "팩트 퀴즈 ID로 팩트 퀴즈를 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "팩트 퀴즈 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 팩트 퀴즈를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"팩트 퀴즈를 찾을 수 없습니다. ID: 1\", \"data\": null}"))),
+            }
+    )
     @GetMapping("/{id}")
     public RsData<FactQuizDtoWithNewsContent> getFactQuizById(@PathVariable Long id) {
         FactQuiz factQuiz = factQuizService.findById(id);
@@ -61,6 +93,18 @@ public class FactQuizController {
     }
 
     @Operation(summary = "팩트 퀴즈 삭제", description = "팩트 퀴즈 ID로 팩트 퀴즈를 삭제합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "팩트 퀴즈 삭제 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 200, \"msg\": \"팩트 퀴즈 삭제 성공. ID: 1\", \"data\": null}"))),
+                    @ApiResponse(responseCode = "404", description = "팩트 퀴즈를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = RsData.class),
+                                    examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"팩트 퀴즈를 찾을 수 없습니다. ID: 1\", \"data\": null}")))
+            }
+    )
     @DeleteMapping("/{id}")
     public RsData<Void> deleteFactQuiz(@PathVariable Long id) {
         factQuizService.delete(id);

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -7,6 +7,7 @@ import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.service.FactQuizService;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,6 +33,7 @@ public class FactQuizController {
             value = {
                     @ApiResponse(responseCode = "200", description = "팩트 퀴즈 (전체) 목록 조회 성공",
                             content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = FactQuizDto.class)),
                                     schema = @Schema(implementation = RsData.class))),
             }
     )
@@ -53,6 +55,7 @@ public class FactQuizController {
             value = {
                     @ApiResponse(responseCode = "200", description = "팩트 퀴즈 목록 조회 성공",
                             content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = FactQuizDto.class)),
                                     schema = @Schema(implementation = RsData.class)))
             }
     )


### PR DESCRIPTION
## 📢 기능 설명
퀴즈 도메인 api 문서 작성
- 예외의 경우 구현 중 예외처리한 에러에 대해서만 작성했고, 서버 오류로 인한 500 에러는 포함하지 않았습니다.
- 기능 테스트 편의를 위해 유저 인증 절차를 아직 구현하지 않아 후에 403 에러가 추가될 수 있습니다.
 
필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #104 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 일일 퀴즈, 상세 퀴즈, 팩트 퀴즈 API에 OpenAPI(Swagger) 문서화 주석이 추가되어 응답 예시 및 설명이 개선되었습니다.

* **버그 수정**
  * 존재하지 않는 뉴스 또는 퀴즈 요청 시 오류 응답 코드가 400에서 404로 일관성 있게 변경되어, 리소스 미존재 상황이 명확하게 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->