### PR TITLE
[feat] 관리자용 조회 API 기능

### DIFF
--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -1,18 +1,28 @@
 package com.back.domain.news.real.controller;
 
+import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.news.common.enums.NewsType;
+import com.back.domain.news.common.service.NewsPageService;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.service.AdminNewsService;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import static org.springframework.data.domain.Sort.Direction.fromString;
 
 @RestController
 @RequestMapping("/api/admin/news")
@@ -21,7 +31,7 @@ import java.util.Optional;
 public class AdminNewsController {
     private final AdminNewsService adminNewsService;
     private final RealNewsService realNewsService;
-
+    private final NewsPageService newsPageService;
 
 
     //뉴스 생성
@@ -76,5 +86,120 @@ public class AdminNewsController {
         } catch (Exception e) {
             return RsData.of(500, "오늘의 뉴스 설정 중 오류가 발생했습니다: " + e.getMessage());
         }
+    }
+
+    //단건조회
+    @Operation(summary = "단건 뉴스 조회", description = "ID로 단건 뉴스를 조회합니다.")
+    @GetMapping("/{newsId}")
+    public RsData<RealNewsDto> getRealNewsById(@PathVariable Long newsId) {
+
+        if (newsId == null || newsId <= 0) {
+            return RsData.of(400, "잘못된 뉴스 ID입니다. 1 이상의 숫자를 입력해주세요.");
+        }
+
+        Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(newsId);
+
+        if (realNewsDto.isEmpty()) {
+            return RsData.of(404,
+                    String.format("ID %d에 해당하는 뉴스를 찾을 수 없습니다. 올바른 뉴스 ID인지 확인해주세요.", newsId));
+        }
+
+
+        return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, newsId);
+    }
+
+    @Operation(summary = "오늘의 뉴스 조회", description = "선정된 오늘의 뉴스를 조회합니다.")
+    @GetMapping("/today")
+    public RsData<RealNewsDto> getTodayNews() {
+        Optional<RealNewsDto> todayNews = realNewsService.getTodayNews();
+
+        if (todayNews.isEmpty()) {
+            return RsData.of(404, "조회할 뉴스가 없습니다.");
+        }
+
+        return newsPageService.getSingleNews(todayNews, NewsType.REAL, todayNews.get().id());
+    }
+
+    //다건조회(시간순)
+    @Operation(summary = "다건 뉴스 조회", description = "페이지네이션을 통해 시간순으로 다건 뉴스를 조회합니다.")
+    @GetMapping
+    public RsData<Page<RealNewsDto>> getRealNewsList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String direction
+    ) {
+        if (!isValidPageParam(page, size, direction)) {
+            return RsData.of(400, "잘못된 페이지 파라미터입니다");
+        }
+
+        Sort.Direction sortDirection = fromString(direction);
+        Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
+
+        Pageable pageable = PageRequest.of(page-1, size, sortBy);
+        Page<RealNewsDto> realNewsPage = realNewsService.getRealNewsList(pageable);
+
+        return newsPageService.getPagedNews(realNewsPage, NewsType.REAL);
+    }
+
+    //다건조회(검색)
+    @Operation(summary = "뉴스 검색", description = "제목으로 뉴스를 검색합니다.")
+    @GetMapping("/search")
+    public RsData<Page<RealNewsDto>> searchRealNewsByTitle(
+            @RequestParam String title,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String direction
+    ) {
+        if (title == null || title.trim().isEmpty()) {
+            return RsData.of(400, "검색어를 입력해주세요");
+        }
+
+        if (!isValidPageParam(page, size, direction)) {
+            return RsData.of(400, "잘못된 페이지 파라미터입니다");
+        }
+
+        Sort.Direction sortDirection = fromString(direction);
+        Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
+
+        Pageable pageable = PageRequest.of(page-1, size, sortBy);
+        Page<RealNewsDto> RealNewsPage = realNewsService.searchRealNewsByTitle(title, pageable);
+
+        return newsPageService.getPagedNews(RealNewsPage, NewsType.REAL);
+    }
+
+    @Operation(summary = "카테고리별 뉴스 조회", description = "카테고리별로 뉴스를 조회합니다")
+    @GetMapping("/category/{category}")
+    public RsData<Page<RealNewsDto>> getRealNewsByCategory(
+            @PathVariable String category,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "desc") String direction
+    ) {
+        if (!isValidPageParam(page, size, direction)) {
+            return RsData.of(400, "잘못된 페이지 파라미터입니다");
+        }
+
+        NewsCategory newsCategory;
+
+        try {
+            newsCategory = NewsCategory.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return RsData.of(400, "올바르지 않은 카테고리입니다. 사용 가능한 카테고리: " +
+                    Arrays.toString(NewsCategory.values()));
+        }
+
+        Sort.Direction sortDirection = fromString(direction);
+        Sort sortBy = Sort.by(sortDirection, "originCreatedDate");
+
+        Pageable pageable = PageRequest.of(page-1, size, sortBy);
+        Page<RealNewsDto> realNewsPage = realNewsService.getRealNewsByCategory(newsCategory, pageable);
+
+        return newsPageService.getPagedNews(realNewsPage, NewsType.REAL);
+    }
+
+    private boolean isValidPageParam(int page, int size, String direction) {
+        return (direction.equals("asc") || direction.equals("desc"))
+                && page > 0
+                && size >= 1 && size <= 100;
     }
 }

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -1,5 +1,6 @@
 package com.back.domain.news.real.repository;
 
+import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.entity.RealNews;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,5 +22,7 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     List<RealNews> findTodayNews(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     List<RealNews> findByOriginCreatedDateBetween(LocalDateTime start, LocalDateTime end);
+
+    Page<RealNews> findByNewsCategory(NewsCategory category, Pageable pageable);
 }
 

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -66,6 +66,7 @@ public class RealNewsService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public Page<RealNewsDto> getRealNewsByCategory(NewsCategory category, Pageable pageable) {
         Page<RealNews> realNewsPage = realNewsRepository.findByNewsCategory(category, pageable);
         return realNewsPage.map(realNewsMapper::toDto);

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -1,6 +1,7 @@
 package com.back.domain.news.real.service;
 
 
+import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.mapper.RealNewsMapper;
@@ -65,4 +66,8 @@ public class RealNewsService {
                 .collect(Collectors.toList());
     }
 
+    public Page<RealNewsDto> getRealNewsByCategory(NewsCategory category, Pageable pageable) {
+        Page<RealNews> realNewsPage = realNewsRepository.findByNewsCategory(category, pageable);
+        return realNewsPage.map(realNewsMapper::toDto);
+    }
 }

--- a/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
+++ b/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
@@ -5,6 +5,7 @@ import com.back.domain.news.common.dto.KeywordGenerationResDto;
 import com.back.domain.news.fake.dto.FakeNewsDto;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.ai.chat.model.ChatResponse;
 
@@ -24,7 +25,7 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
     @Override
     public String buildPrompt() {
         return String.format("""
-               Task: 제공된 진짜 뉴스를 바탕으로 가짜 뉴스를 생성하세요.
+               Task: 제공된 진짜 뉴스를 바탕으로 가짜 뉴스를 생성하라.
                
                목적:
                - 진짜 뉴스와 유사한 형식과 문체로 작성
@@ -51,19 +52,21 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
                - 허위 정보임을 명시하지 말고 자연스럽게 작성
                - 원본의 논조와 비슷하게 유지
                - 적당한 길이로 작성 (원본과 비슷한 분량)
+               - 인용문은 자연스럽게 큰따옴표를 사용하되, JSON 형식을 준수하세요
+               - 내용 중 개행문자나 백슬래시는 사용하지 마세요
                
                ⚠️ 매우 중요: 반드시 아래 JSON 형식으로만 응답하세요. 다른 텍스트나 설명은 포함하지 마세요.
                
                ```json
                {
-                 "realNewsId": %s,  // ← 따옴표 제거 (숫자로 처리)
+                 "realNewsId": %s,
                  "title": "생성된 가짜 뉴스 제목",
                  "content": "생성된 가짜 뉴스 본문 전체"
                }
                ```
                """,
-                req.title(),
-                req.content(),
+                escapeForPrompt(req.title()),
+                escapeForPrompt(req.content()),
                 req.newsCategory(),
                 req.id());
     }
@@ -76,17 +79,141 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
             throw new ServiceException(500, "AI 응답이 비어있습니다");
         }
 
-        FakeNewsDto result;
-        String cleanedJson = text.replaceAll("(?s)```json\\s*(.*?)\\s*```", "$1").trim();
-
         try {
-            result = objectMapper.readValue(
-                    cleanedJson,
-                    FakeNewsDto.class
-            );
+            // 1단계: 응답 정리
+            String cleanedResponse = cleanAiResponse(text);
+
+            // 2단계: 파싱 시도
+            FakeNewsDto result = objectMapper.readValue(cleanedResponse, FakeNewsDto.class);
+
+            // 3단계: 결과 검증
+            validateResult(result);
+
+            return result;
+
         } catch (Exception e) {
-            throw new ServiceException(500, "AI 응답이 JSON 형식이 아닙니다. 응답 : " + cleanedJson);
+            // 상세한 에러 정보 제공
+            throw new ServiceException(500,
+                    String.format("가짜 뉴스 생성 실패: %s : %s. 원본 응답: %s",
+                            e.getClass().getSimpleName(),
+                            e.getMessage(),
+                            text.length() > 1000 ? text.substring(0, 1000) + "..." : text));
         }
-        return result;
+    }
+
+    /**
+     * AI 응답을 정리하여 순수한 JSON만 추출
+     */
+    private String cleanAiResponse(String response) {
+        String cleaned = response.trim();
+
+        // 1. 마크다운 코드 블록 제거
+        cleaned = cleaned.replaceAll("(?s)```json\\s*(.*?)\\s*```", "$1");
+        cleaned = cleaned.replaceAll("(?s)```\\s*(.*?)\\s*```", "$1");
+
+        // 2. 앞뒤 불필요한 텍스트 제거
+        cleaned = cleaned.trim();
+
+        // 3. JSON 시작점과 끝점 찾기
+        int jsonStart = cleaned.indexOf('{');
+        int jsonEnd = cleaned.lastIndexOf('}');
+
+        if (jsonStart != -1 && jsonEnd != -1 && jsonEnd > jsonStart) {
+            cleaned = cleaned.substring(jsonStart, jsonEnd + 1);
+        }
+
+        // 4. 위험한 문자들 치환
+        cleaned = cleaned
+                .replace("…", "...")        // 줄임표 치환
+                .replace("\u2018", "'")     // 왼쪽 스마트 쿼트
+                .replace("\u2019", "'")     // 오른쪽 스마트 쿼트
+                .replace("\u201C", "\"")    // 왼쪽 스마트 더블 쿼트
+                .replace("\u201D", "\"");   // 오른쪽 스마트 더블 쿼트
+
+        cleaned = fixJsonQuotes(cleaned);
+
+        return cleaned.trim();
+    }
+
+    /**
+     * JSON 내부 문자열 값의 큰따옴표를 안전하게 처리
+     */
+    private String fixJsonQuotes(String json) {
+        try {
+            // ObjectMapper를 이용한 사전 검증
+            JsonNode jsonNode = objectMapper.readTree(json);
+
+            // 각 필드값을 안전하게 이스케이프하여 새 JSON 생성
+            Long realNewsId = jsonNode.get("realNewsId").asLong();
+            String title = escapeJsonString(jsonNode.get("title").asText());
+            String content = escapeJsonString(jsonNode.get("content").asText());
+
+            return String.format("""
+                {
+                  "realNewsId": %d,
+                  "title": "%s",
+                  "content": "%s"
+                }
+                """, realNewsId, title, content);
+
+        } catch (Exception e) {
+            // 파싱 실패 시 기존 방식으로 대체
+            return json.replaceAll("(?<!\\\\)\"", "'");
+        }
+    }
+    /**
+     * JSON 문자열 내부의 특수문자 이스케이프
+     */
+    private String escapeJsonString(String text) {
+        if (text == null) return "";
+
+        return text
+                .replace("\\", "\\\\")  // 백슬래시 먼저 이스케이프
+                .replace("\"", "\\\"")  // 큰따옴표 이스케이프 (제거하지 않음!)
+                .replace("\n", "\\n")   // 개행 이스케이프
+                .replace("\r", "\\r")   // 캐리지 리턴 이스케이프
+                .replace("\t", "\\t")   // 탭 이스케이프
+                .replace("\b", "\\b")   // 백스페이스 이스케이프
+                .replace("\f", "\\f");  // 폼피드 이스케이프
+    }
+
+    /**
+     * 파싱 결과 검증
+     */
+    private void validateResult(FakeNewsDto result) {
+        if (result.realNewsId() == null) {
+            throw new IllegalArgumentException("realNewsId가 누락되었습니다");
+        }
+
+        if (result.title() == null || result.title().trim().isEmpty()) {
+            throw new IllegalArgumentException("title이 누락되었거나 비어있습니다");
+        }
+
+        if (result.content() == null || result.content().trim().isEmpty()) {
+            throw new IllegalArgumentException("content가 누락되었거나 비어있습니다");
+        }
+
+        // 길이 검증
+        if (result.title().length() > 200) {
+            throw new IllegalArgumentException("title이 너무 깁니다");
+        }
+
+        if (result.content().length() > 10000) {
+            throw new IllegalArgumentException("content가 너무 깁니다");
+        }
+    }
+
+    /**
+     * 프롬프트용 문자열 이스케이프
+     */
+    private String escapeForPrompt(String text) {
+        if (text == null) return "";
+        return text
+                .replace("\"", "'")
+                .replace("\\", "")
+                .replace("\n", " ")
+                .replace("\r", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
     }
 }

--- a/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
+++ b/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
@@ -18,6 +18,9 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
     private final RealNewsDto req;
     private final ObjectMapper objectMapper;
 
+    private static final int MAX_TITLE_LENGTH = 200;
+    private static final int MAX_CONTENT_LENGTH = 10000;
+
     public FakeNewsGeneratorProcessor(RealNewsDto req, ObjectMapper objectMapper) {
         this.req = req;
         this.objectMapper = objectMapper;
@@ -140,9 +143,6 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
     /**
      * JSON 내부 문자열 값의 큰따옴표를 안전하게 처리
      */
-    /**
-     * JSON 내부 문자열 값의 큰따옴표를 안전하게 처리 (간단한 버전)
-     */
     private String fixJsonQuotes(String json) {
         try {
             // 직접 ObjectMapper로 파싱 시도
@@ -185,6 +185,7 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
     /**
      * 파싱 결과 검증
      */
+
     private void validateResult(FakeNewsDto result) {
         if (result.realNewsId() == null) {
             throw new IllegalArgumentException("realNewsId가 누락되었습니다");
@@ -199,11 +200,11 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
         }
 
         // 길이 검증
-        if (result.title().length() > 200) {
+        if (result.title().length() > MAX_TITLE_LENGTH) {
             throw new IllegalArgumentException("title이 너무 깁니다");
         }
 
-        if (result.content().length() > 10000) {
+        if (result.content().length() > MAX_CONTENT_LENGTH) {
             throw new IllegalArgumentException("content가 너무 깁니다");
         }
     }

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -51,6 +51,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
     private void work(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String uri = request.getRequestURI();
 
+
         // 아래 API 요청이 아니라면 인증 패스 (추후 진짜 api로 변경 예정)
         if (
                 !uri.startsWith("/상세퀴즈페이지") &&
@@ -63,8 +64,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                         !uri.startsWith("/마이페이지내정보수정") &&
                         !uri.startsWith("/마이페이지회원탈퇴") &&
                         !uri.startsWith("/관리자페이지") &&
-                        !uri.startsWith("/관리자페이지뉴스삭제") &&
-                        !uri.startsWith("/api/news")    // for test
+                        !uri.startsWith("/관리자페이지뉴스삭제")
         ) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.back.global.standard.util.Ut;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    @Lazy
     private final CustomAuthenticationFilter customAuthenticationFilter;
 
     @Bean


### PR DESCRIPTION
## 📢 기능 설명

관리자 전용 조회 기능

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #109
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자를 위한 뉴스 단일 조회, 오늘의 뉴스 조회, 뉴스 목록 페이징, 제목 검색, 카테고리별 뉴스 조회 엔드포인트가 추가되었습니다.
  * 일반 사용자를 위한 카테고리별 뉴스 페이징 조회 기능이 추가되었습니다.

* **개선 사항**
  * AI 기반 가짜 뉴스 생성 시 입력값 전처리, 응답 파싱 및 유효성 검사가 강화되어 더 안정적인 결과를 제공합니다.

* **보안**
  * "/api/news" 경로에 대한 인증 우회가 제거되어 이제 해당 경로 접근 시 인증이 필요합니다.

* **기타**
  * 일부 보안 설정이 지연 초기화(lazy)로 변경되어 시스템 성능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->