### PR TITLE
[feat]:상세퀴즈 풀이 -> 퀴즈 히스토리에 저장#1

### DIFF
--- a/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
+++ b/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
@@ -3,7 +3,6 @@ package com.back.domain.member.quizhistory.controller;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
-import com.back.domain.member.quizhistory.entity.QuizHistory;
 import com.back.domain.member.quizhistory.service.QuizHistoryService;
 import com.back.domain.quiz.QuizType;
 import com.back.global.exception.ServiceException;
@@ -11,11 +10,11 @@ import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -37,31 +36,31 @@ public class QuizHistoryController {
             String answer
     ) {}
 
-    @PostMapping
-    @Operation(summary = "퀴즈 히스토리 생성 , 유저가 퀴즈를 풀고-> 서버에서 정답확인 + 경험치부여 -> 퀴즈 히스토리 생성 -> 클라이언트에 반환")
-    @Transactional
-    public RsData<QuizHistoryDto> createQuizHistory(@RequestBody @Valid QuizHistoryCreateReqBody reqBody){
-
-        Member actor = rq.getActor();
-
-        if (actor == null) {
-            throw new ServiceException(401, "로그인이 필요합니다.");
-        }
-
-        // 퀴즈 히스토리 생성
-        QuizHistory history = quizHistoryService.createQuizHistory(
-                actor,
-                reqBody.quizId,
-                reqBody.quizType,
-                reqBody.answer
-        );
-
-        return new RsData<>(
-                200,
-                "퀴즈 히스토리 생성 성공",
-                new QuizHistoryDto(history)
-        );
-    }
+//    @PostMapping
+//    @Operation(summary = "퀴즈 히스토리 생성 , 유저가 퀴즈를 풀고-> 서버에서 정답확인 + 경험치부여 -> 퀴즈 히스토리 생성 -> 클라이언트에 반환")
+//    @Transactional
+//    public RsData<QuizHistoryDto> createQuizHistory(@RequestBody @Valid QuizHistoryCreateReqBody reqBody){
+//
+//        Member actor = rq.getActor();
+//
+//        if (actor == null) {
+//            throw new ServiceException(401, "로그인이 필요합니다.");
+//        }
+//
+//        // 퀴즈 히스토리 생성
+//        QuizHistory history = quizHistoryService.createQuizHistory(
+//                actor,
+//                reqBody.quizId,
+//                reqBody.quizType,
+//                reqBody.answer
+//        );
+//
+//        return new RsData<>(
+//                200,
+//                "퀴즈 히스토리 생성 성공",
+//                new QuizHistoryDto(history)
+//        );
+//    }
 
     @GetMapping
     @Operation(summary = "현재 로그인한 유저의 퀴즈 풀이 기록 다건 조회")

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -1,13 +1,10 @@
 package com.back.domain.member.quizhistory.service;
 
 import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
 import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
 import com.back.domain.quiz.QuizType;
-import com.back.domain.quiz.detail.repository.DetailQuizRepository;
-import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,46 +16,6 @@ import java.util.List;
 public class QuizHistoryService {
 
     private final QuizHistoryRepository quizHistoryRepository;
-    private final MemberRepository memberRepository;
-
-    // detail, fact, daily 퀴즈 도메인별
-    private final DetailQuizRepository detailQuizRepository;
-    //private final FactQuizRepository factQuizRepository;
-    //private final DailyQuizRepository dailyQuizRepository;
-
-
-    @Transactional
-    public QuizHistory createQuizHistory(Member actor, Long quizId, QuizType quizType, String answer) {
-
-        // 퀴즈 정답 가져오기
-        String correctAnswer =
-                switch (quizType) {
-                    case DETAIL -> detailQuizRepository.findById(quizId)
-                            .orElseThrow(() -> new ServiceException(400, "존재하지 않는 퀴즈입니다."))
-                            .getCorrectAnswerText();
-                    //case FACT -> factQuizRepository.findById(quizId).orElseThrow(() -> new ServiceException(400,"존재하지 않는 퀴즈입니다.")).getCorrectAnswerText();
-                    //case DAILY -> dailyQuizRepository.findById(quizId).orElseThrow(() -> new ServiceException(400,"존재하지 않는 퀴즈입니다.")).getCorrectAnswerText();
-
-                    default -> throw new ServiceException(400, "지원하지 않는 퀴즈 타입입니다.");
-                };
-
-
-        // equals로 하면 안될거같고, contains로 해야할듯
-        boolean isCorrect = correctAnswer.contains(answer);
-        int gainExp = isCorrect ? 100 : 0; // 정답일 경우 경험치 100점 부여
-
-        //경험치 적용
-        actor.setExp(actor.getExp() + gainExp);
-
-        // 퀴즈 히스토리 생성 , 연관관계 설정
-        QuizHistory quizHistory = actor.addQuizHistory(quizId, quizType, answer, isCorrect, gainExp);
-
-
-        // 양방향 연관관계 관리 및 저장, actor저장하면 quizHistory도 저장됨
-        memberRepository.save(actor);
-
-        return quizHistory;
-    }
 
     @Transactional(readOnly = true)
     public List<QuizHistoryDto> getQuizHistoriesByMember(Member actor) {
@@ -73,8 +30,9 @@ public class QuizHistoryService {
                 .toList();
     }
 
+    @Transactional
     public void save(Member actor, Long id,QuizType quizType, String answer, boolean isCorrect, int gainExp) {
-        //빌더로해줘
+
         QuizHistory quizHistory = QuizHistory.builder()
                 .member(actor)
                 .quizId(id)

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -72,4 +72,19 @@ public class QuizHistoryService {
                 .map(QuizHistoryDto::new)
                 .toList();
     }
+
+    public void save(Member actor, Long id,QuizType quizType, String answer, boolean isCorrect, int gainExp) {
+        //빌더로해줘
+        QuizHistory quizHistory = QuizHistory.builder()
+                .member(actor)
+                .quizId(id)
+                .quizType(quizType)
+                .answer(answer)
+                .isCorrect(isCorrect)
+                .gainExp(gainExp)
+                .build();
+
+        // 퀴즈 히스토리 저장
+        quizHistoryRepository.save(quizHistory);
+    }
 }

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -1,8 +1,13 @@
 package com.back.domain.quiz.detail.controller;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.quiz.detail.dto.DetailQuizAnswerDto;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
+import com.back.domain.quiz.detail.entity.Option;
 import com.back.domain.quiz.detail.service.DetailQuizService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +29,7 @@ import java.util.List;
 @Tag(name = "DetailQuizController", description = "상세 퀴즈 관련 API")
 public class DetailQuizController {
     private final DetailQuizService detailQuizService;
+    private final Rq rq;
 
     // 상세 퀴즈 목록 조회(전체 조회)
     @Operation(summary = "전체 조회", description = "상세 퀴즈 목록을 조회합니다.")
@@ -154,6 +161,25 @@ public class DetailQuizController {
                 "상세 퀴즈 수정 성공",
                 new DetailQuizDto(updatedQuiz)
         );
+    }
+
+
+    @Operation(summary = "퀴즈 정답 제출", description = "퀴즈 ID로 상세 퀴즈의 정답을 제출합니다.")
+    @PostMapping("/submit/{id}")
+    public RsData<DetailQuizAnswerDto> submitDetailQuizAnswer(@PathVariable Long id, @RequestBody @Valid @NotNull Option selectedOption) {
+
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        DetailQuizAnswerDto submittedQuiz = detailQuizService.submitDetailQuizAnswer(actor,id, selectedOption);
+
+        return new RsData<>(
+                200,
+                "퀴즈 정답 제출 성공",
+                submittedQuiz
+                );
     }
 
 }

--- a/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizAnswerDto.java
+++ b/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizAnswerDto.java
@@ -1,0 +1,23 @@
+package com.back.domain.quiz.detail.dto;
+
+import com.back.domain.quiz.QuizType;
+import com.back.domain.quiz.detail.entity.Option;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DetailQuizAnswerDto {
+
+    private Long quizId;
+    private String question; //
+    private Option correctOption; // 정답 선택지
+    private Option selectedOption; // 사용자가 선택한 답변
+
+    boolean isCorrect; // 정답 여부
+    int gainExp; // 경험치 획득량
+    private QuizType quizType; // 퀴즈 타입
+
+}

--- a/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
+++ b/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
@@ -59,6 +59,11 @@ public class DetailQuiz {
         };
     }
 
+    // 정답 판별 메소드
+    public boolean isCorrect(Option userSelectedOption) {
+        return this.correctOption == userSelectedOption;
+    }
+
     public DetailQuiz(String question, String option1, String option2, String option3, Option correctOption) {
         this.question = question;
         this.option1 = option1;

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
@@ -121,17 +121,17 @@ public class DetailQuizService {
         DetailQuiz quiz = detailQuizRepository.findById(id)
                 .orElseThrow(() -> new ServiceException(404, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));
 
+        Member managedActor = memberRepository.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+
         boolean isCorrect = quiz.isCorrect(selectedOption);
 
         int gainExp = isCorrect ? 10 : 0; // 정답 제출 시 경험치 10점 부여
 
-        // 영속 상태로 변경
-        Member managedActor = memberRepository.findById(actor.getId())
-                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
 
         managedActor.setExp(managedActor.getExp() + gainExp);
 
-        quizHistoryService.save(actor, id, quiz.getQuizType(), String.valueOf(selectedOption), isCorrect, gainExp); // 퀴즈 히스토리 저장
+        quizHistoryService.save(managedActor, id, quiz.getQuizType(), String.valueOf(selectedOption), isCorrect, gainExp); // 퀴즈 히스토리 저장
 
         return new DetailQuizAnswerDto(
                 quiz.getId(),


### PR DESCRIPTION
## 📢 기능 설명
detail퀴즈 풀이시 퀴즈 히스토리에 저장


필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #135 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 퀴즈 답안 제출을 위한 새로운 API 엔드포인트가 추가되었습니다. 사용자는 퀴즈 답안을 제출하고, 정답 여부와 획득 경험치를 확인할 수 있습니다.
  * 퀴즈 답안 제출 시, 정답 여부와 획득 경험치, 선택/정답 옵션 등 상세 결과가 반환됩니다.
  * 퀴즈 풀이 기록이 저장되어 경험치가 자동으로 반영됩니다.
* **기능 변경**
  * 퀴즈 풀이 기록 저장 방식이 간소화되어, 내부 검증 없이 직접 기록 저장이 이루어집니다.
* **기능 비활성화**
  * 기존 퀴즈 풀이 기록 생성용 POST API가 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->