### PR TITLE
[feat]: 오늘의 퀴즈풀이 기능 구현 + 중복풀이 못하게 handler처리#1

### DIFF
--- a/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
+++ b/src/main/java/com/back/domain/member/quizhistory/controller/QuizHistoryController.java
@@ -4,13 +4,11 @@ package com.back.domain.member.quizhistory.controller;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
 import com.back.domain.member.quizhistory.service.QuizHistoryService;
-import com.back.domain.quiz.QuizType;
 import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,41 +24,6 @@ public class QuizHistoryController {
 
     private final QuizHistoryService quizHistoryService;
     private final Rq rq;
-
-    record QuizHistoryCreateReqBody(
-            @NotNull
-            Long quizId,
-            @NotNull
-            QuizType quizType,
-            @NotNull
-            String answer
-    ) {}
-
-//    @PostMapping
-//    @Operation(summary = "퀴즈 히스토리 생성 , 유저가 퀴즈를 풀고-> 서버에서 정답확인 + 경험치부여 -> 퀴즈 히스토리 생성 -> 클라이언트에 반환")
-//    @Transactional
-//    public RsData<QuizHistoryDto> createQuizHistory(@RequestBody @Valid QuizHistoryCreateReqBody reqBody){
-//
-//        Member actor = rq.getActor();
-//
-//        if (actor == null) {
-//            throw new ServiceException(401, "로그인이 필요합니다.");
-//        }
-//
-//        // 퀴즈 히스토리 생성
-//        QuizHistory history = quizHistoryService.createQuizHistory(
-//                actor,
-//                reqBody.quizId,
-//                reqBody.quizType,
-//                reqBody.answer
-//        );
-//
-//        return new RsData<>(
-//                200,
-//                "퀴즈 히스토리 생성 성공",
-//                new QuizHistoryDto(history)
-//        );
-//    }
 
     @GetMapping
     @Operation(summary = "현재 로그인한 유저의 퀴즈 풀이 기록 다건 조회")

--- a/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
+++ b/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
@@ -17,6 +17,10 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @EntityListeners(AuditingEntityListener.class)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Table(
+        name = "quiz_history",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "quiz_id", "quizType"})
+)
 public class QuizHistory {
 
     @Id

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -5,7 +5,9 @@ import com.back.domain.member.quizhistory.dto.QuizHistoryDto;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
 import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
 import com.back.domain.quiz.QuizType;
+import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +45,10 @@ public class QuizHistoryService {
                 .build();
 
         // 퀴즈 히스토리 저장
-        quizHistoryRepository.save(quizHistory);
+        try {
+            quizHistoryRepository.save(quizHistory);
+        } catch (DataIntegrityViolationException e) {
+            throw new ServiceException(400, "이미 푼 문제입니다.");
+        }
     }
 }

--- a/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
+++ b/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
@@ -1,8 +1,13 @@
 package com.back.domain.quiz.daily.controller;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.quiz.daily.dto.DailyQuizAnswerDto;
 import com.back.domain.quiz.daily.dto.DailyQuizDto;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.service.DailyQuizService;
+import com.back.domain.quiz.detail.entity.Option;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,11 +16,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,6 +29,7 @@ import java.util.List;
 @Tag(name= "DailyQuizController", description = "오늘의 퀴즈 관련 API")
 public class DailyQuizController {
     private final DailyQuizService dailyQuizService;
+    private final Rq rq;
 
     @Operation(summary = "오늘의 퀴즈 조회", description = "오늘의 뉴스 ID로 오늘의 퀴즈(3개)를 조회합니다.")
     @ApiResponses(
@@ -48,6 +53,24 @@ public class DailyQuizController {
                 dailyQuizzes.stream()
                         .map(DailyQuizDto::new)
                         .toList()
+        );
+    }
+
+    @Operation(summary = "오늘의 퀴즈 정답 제출", description = "퀴즈 ID로 오늘의 퀴즈의 정답을 제출합니다.")
+    @PostMapping("/submit/{id}")
+    public RsData<DailyQuizAnswerDto> submitDailyQuizAnswer(@PathVariable Long id, @RequestBody @Valid @NotNull Option selectedOption) {
+
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        DailyQuizAnswerDto submittedQuiz = dailyQuizService.submitDetailQuizAnswer(actor,id, selectedOption);
+
+        return new RsData<>(
+                200,
+                "퀴즈 정답 제출 성공",
+                submittedQuiz
         );
     }
 }

--- a/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizAnswerDto.java
+++ b/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizAnswerDto.java
@@ -1,0 +1,21 @@
+package com.back.domain.quiz.daily.dto;
+
+import com.back.domain.quiz.QuizType;
+import com.back.domain.quiz.detail.entity.Option;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyQuizAnswerDto {
+    private Long quizId;
+    private String question; //
+    private Option correctOption; // 정답 선택지
+    private Option selectedOption; // 사용자가 선택한 답변
+
+    boolean isCorrect; // 정답 여부
+    int gainExp; // 경험치 획득량
+    private QuizType quizType; // 퀴즈 타입
+}

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -1,11 +1,16 @@
 package com.back.domain.quiz.daily.service;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.member.quizhistory.service.QuizHistoryService;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.repository.TodayNewsRepository;
 import com.back.domain.news.today.entity.TodayNews;
+import com.back.domain.quiz.daily.dto.DailyQuizAnswerDto;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.repository.DailyQuizRepository;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
+import com.back.domain.quiz.detail.entity.Option;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +26,8 @@ import java.util.List;
 public class DailyQuizService {
     private final DailyQuizRepository dailyQuizRepository;
     private final TodayNewsRepository todayNewsRepository;
+    private final MemberRepository memberRepository;
+    private final QuizHistoryService quizHistoryService;
 
     @Transactional(readOnly = true)
     public List<DailyQuiz> getDailyQuizzes(Long todayNewsId) {
@@ -77,6 +84,34 @@ public class DailyQuizService {
                 .toList();
 
         dailyQuizRepository.saveAll(dailyQuizzes);
+
+    }
+
+    public DailyQuizAnswerDto submitDetailQuizAnswer(Member actor, Long id, Option selectedOption) {
+        DailyQuiz dailyQuiz = dailyQuizRepository.findById(id)
+                .orElseThrow(() -> new ServiceException(404, "오늘의 퀴즈를 찾을 수 없습니다."));
+
+        Member managedActor = memberRepository.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+
+        DetailQuiz detailQuiz = dailyQuiz.getDetailQuiz();
+
+        boolean isCorrect = detailQuiz.isCorrect(selectedOption);
+        int gainExp = isCorrect ? 10 : 0;
+
+        managedActor.setExp(managedActor.getExp() + gainExp);
+
+        quizHistoryService.save(managedActor, id, dailyQuiz.getQuizType(), String.valueOf(selectedOption), isCorrect, gainExp); // 퀴즈 히스토리 저장
+
+        return new DailyQuizAnswerDto(
+                dailyQuiz.getId(),
+                detailQuiz.getQuestion(),
+                detailQuiz.getCorrectOption(),
+                selectedOption,
+                isCorrect,
+                gainExp,
+                dailyQuiz.getQuizType()
+        );
 
     }
 }

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -87,6 +87,7 @@ public class DailyQuizService {
 
     }
 
+    @Transactional
     public DailyQuizAnswerDto submitDetailQuizAnswer(Member actor, Long id, Option selectedOption) {
         DailyQuiz dailyQuiz = dailyQuizRepository.findById(id)
                 .orElseThrow(() -> new ServiceException(404, "오늘의 퀴즈를 찾을 수 없습니다."));

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -164,7 +164,7 @@ public class DetailQuizController {
     }
 
 
-    @Operation(summary = "퀴즈 정답 제출", description = "퀴즈 ID로 상세 퀴즈의 정답을 제출합니다.")
+    @Operation(summary = "퀴즈 정답 제출", description = "퀴즈 ID로 오늘의 퀴즈의 정답을 제출합니다.")
     @PostMapping("/submit/{id}")
     public RsData<DetailQuizAnswerDto> submitDetailQuizAnswer(@PathVariable Long id, @RequestBody @Valid @NotNull Option selectedOption) {
 

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -69,7 +69,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                         !uri.startsWith("/api/quiz/fact/") && // OX 퀴즈 단건 조회
                         !uri.startsWith("/ox퀴즈제출") &&
                         !uri.startsWith("/오늘의퀴즈페이지") &&
-                        !uri.startsWith("/오늘의퀴즈제출") &&
+                        !uri.startsWith("/api/quiz/daily/") &&
                         !uri.startsWith("/ox퀴즈제출") &&
                         !uri.startsWith("/api/members/info") &&
                         !uri.startsWith("/마이페이지내정보수정") &&


### PR DESCRIPTION
## 📢 기능 설명
오늘의 퀴즈 풀이 기능 구현


<img width="492" height="311" alt="image" src="https://github.com/user-attachments/assets/cc673675-6d45-417a-ae8a-535842ab434a" />




똑같은 문제를 풀면 
<img width="321" height="143" alt="image" src="https://github.com/user-attachments/assets/fbaa1df2-e638-49cb-83fd-11648b0e84d4" />


필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #147 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 오늘의 퀴즈 정답 제출을 위한 API 엔드포인트가 추가되었습니다.
  * 오늘의 퀴즈 정답 제출 시 결과와 경험치 획득 여부를 반환하는 응답 DTO가 도입되었습니다.

* **버그 수정**
  * 퀴즈 풀이 기록 저장 시 중복 풀이에 대한 예외 메시지가 명확하게 안내됩니다.

* **개선 사항**
  * 퀴즈 풀이 기록에 대해 회원, 퀴즈, 퀴즈 타입 조합의 중복 저장이 방지됩니다.
  * 인증 필터에서 오늘의 퀴즈 관련 URI 예외 처리 방식이 개선되었습니다.

* **문서**
  * 상세 퀴즈 정답 제출 API의 설명이 오늘의 퀴즈 제출로 변경되었습니다.

* **기타**
  * 사용하지 않는 퀴즈 풀이 기록 생성 API 및 관련 코드가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->