### PR TITLE
[feat] : 가짜 뉴스 스케줄러 기능 구현

### DIFF
--- a/src/main/java/com/back/domain/news/common/test/controller/TestController.java
+++ b/src/main/java/com/back/domain/news/common/test/controller/TestController.java
@@ -7,6 +7,7 @@ import com.back.domain.news.common.service.KeywordGenerationService;
 import com.back.domain.news.fake.dto.FakeNewsDto;
 import com.back.domain.news.fake.service.FakeNewsService;
 import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.AdminNewsService;
 import com.back.domain.news.real.service.NewsDataService;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.global.rsData.RsData;
@@ -27,11 +28,26 @@ public class TestController {
     private final FakeNewsService fakeNewsService;
     private final RealNewsService realNewsService;
     private final NewsDataService newsDataService;
+    private final AdminNewsService adminNewsService;
 
     @GetMapping("/keywords")
     public KeywordGenerationResDto testKeywords() {
         return keywordGenerationService.generateTodaysKeywords();
     }
+
+
+    //     뉴스 배치 프로세서
+    @GetMapping("/process")
+    public RsData<Void> newsProcess() {
+        try {
+            adminNewsService.dailyNewsProcess();
+
+            return RsData.of(200, "성공");
+        } catch (Exception e) {
+            return RsData.of(500, "실패: " + e.getMessage());
+        }
+    }
+
 
     //-1 -> 내일 이전(모든 키워드 삭제)
     // 0 -> 오늘 이전(어제 키워드까지 삭제)

--- a/src/main/java/com/back/domain/news/fake/service/AdminFakeNewsService.java
+++ b/src/main/java/com/back/domain/news/fake/service/AdminFakeNewsService.java
@@ -1,0 +1,47 @@
+package com.back.domain.news.fake.service;
+
+import com.back.domain.news.fake.dto.FakeNewsDto;
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.RealNewsService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminFakeNewsService {
+
+    private final FakeNewsService fakeNewsService;
+    private final RealNewsService realNewsService;
+
+
+    @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시에 실행
+    public void dailyFakeNewsProcess() {
+        try {
+            List<RealNewsDto> realNewsDtos = realNewsService.getRealNewsListCreatedToday();
+
+            if (realNewsDtos == null || realNewsDtos.isEmpty()) {
+                log.warn("오늘 생성된 실제 뉴스가 없습니다.");
+                return;
+            }
+            log.info("처리 대상 실제 뉴스: {}개", realNewsDtos.size());
+
+            List<FakeNewsDto> fakeNewsDtos = fakeNewsService.generateAndSaveAllFakeNews(realNewsDtos);
+
+            log.info("=== 일일 가짜뉴스 생성 배치 완료 ===");
+            log.info("요청: {}개, 성공: {}개, 실패: {}개",
+                    realNewsDtos.size(),
+                    fakeNewsDtos.size(),
+                    realNewsDtos.size() - fakeNewsDtos.size());
+
+        } catch (ServiceException e) {
+            log.error("가짜 뉴스 생성 중 오류 발생: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -63,11 +63,11 @@ public class AdminNewsController {
     @GetMapping("/process")
     public RsData<List<RealNewsDto>> newsProcess() {
         try {
-            List<RealNewsDto> result = adminNewsService.dailyNewsProcess();
+            adminNewsService.dailyNewsProcess();
 
-            return RsData.of(200, "성공", result);
+            return RsData.of(200, "뉴스 생성 성공");
         } catch (Exception e) {
-            return RsData.of(500, "실패: " + e.getMessage());
+            return RsData.of(500, "뉴스 생성 실패 : " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -30,7 +30,6 @@ public class RealNews {
     @GeneratedValue(strategy = IDENTITY)
     private long id;
 
-    @Column(unique = true)
     private String title;
 
     @Lob

--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -2,41 +2,17 @@ package com.back.domain.news.real.service;
 
 import com.back.domain.news.common.dto.AnalyzedNewsDto;
 import com.back.domain.news.common.dto.NaverNewsDto;
-import com.back.domain.news.common.dto.NewsDetailDto;
-import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.common.service.KeywordGenerationService;
 import com.back.domain.news.common.service.NewsAnalysisService;
 import com.back.domain.news.real.dto.RealNewsDto;
-import com.back.domain.news.real.entity.RealNews;
-import com.back.domain.news.real.mapper.RealNewsMapper;
-import com.back.domain.news.real.repository.RealNewsRepository;
-import com.back.domain.news.real.repository.TodayNewsRepository;
-import com.back.domain.news.today.entity.TodayNews;
-import com.back.global.exception.ServiceException;
-import com.back.global.util.HtmlEntityDecoder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -50,20 +26,22 @@ public class AdminNewsService {
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
-    public List<RealNewsDto> dailyNewsProcess(){
+    public void dailyNewsProcess(){
         List<String> keywords = keywordGenerationService.generateTodaysKeywords().getKeywords();
         //   속보랑 기타키워드 추가
-        List<String> additionalKeywords = newsDataService.addKeywords(keywords, STATIC_KEYWORD);
+        List<String> newsKeywords = newsDataService.addKeywords(keywords, STATIC_KEYWORD);
 
-        List<NaverNewsDto> allNews = newsDataService.collectMetaDataFromNaver(keywords);
+        List<NaverNewsDto> newsKeywordsAfterAdd = newsDataService.collectMetaDataFromNaver(newsKeywords);
 
-        List<RealNewsDto> allRealNewsBeforeFilter = newsDataService.createRealNewsDtoByCrawl(allNews);
+        List<RealNewsDto> NewsBeforeFilter = newsDataService.createRealNewsDtoByCrawl(newsKeywordsAfterAdd);
 
-        List<AnalyzedNewsDto> allRealNewsAfterFilter = newsAnalysisService.filterAndScoreNews(allRealNewsBeforeFilter);
+        List<RealNewsDto> NewsRemovedDuplicateTitles = newsDataService.removeDuplicateTitles(NewsBeforeFilter);
 
-        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(allRealNewsAfterFilter);
+        List<AnalyzedNewsDto> newsAfterFilter = newsAnalysisService.filterAndScoreNews(NewsRemovedDuplicateTitles);
 
-        return newsDataService.saveAllRealNews(selectedNews);
+        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(newsAfterFilter);
+
+        List<RealNewsDto> savedNews = newsDataService.saveAllRealNews(selectedNews);
     }
 
 }

--- a/src/main/java/com/back/domain/news/real/service/NewsDataService.java
+++ b/src/main/java/com/back/domain/news/real/service/NewsDataService.java
@@ -388,4 +388,13 @@ public class NewsDataService {
                 .distinct()
                 .toList();
     }
+
+    public List<RealNewsDto> removeDuplicateTitles(List<RealNewsDto> newsBeforeFilter) {
+        // 제목을 기준으로 중복 제거
+        Map<String, RealNewsDto> uniqueNewsMap = new LinkedHashMap<>();
+        for (RealNewsDto news : newsBeforeFilter) {
+            uniqueNewsMap.put(news.title(), news);
+        }
+        return new ArrayList<>(uniqueNewsMap.values());
+    }
 }

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -60,6 +60,7 @@ public class RealNewsService {
         LocalDateTime start = LocalDate.now().atStartOfDay(); // 오늘 00:00
         LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
 
+//아이디순 정렬할것
         List<RealNews> realNewsList = realNewsRepository.findByOriginCreatedDateBetween(start, end);
         return realNewsList.stream()
                 .map(realNewsMapper::toDto)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   base-url: "https://openapi.naver.com/v1/search/news?query="
   news:
-    display: 3
+    display: 1
     sort: sim
   crawling:
     delay: 1000 # 줄이지 말아주세요


### PR DESCRIPTION
## 📢 기능 설명

- real news title 유니크 키 처리로 인한 종료 문제 해결 ( title 유니크 속성 풀고 제목 중복확인체크)
- 진짜 뉴스 생성 후 db저장

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #144
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 테스트용 뉴스 프로세스 실행 엔드포인트가 추가되었습니다.
  * 일일 가짜 뉴스 자동 생성 서비스가 도입되었습니다.

* **기능 개선**
  * 뉴스 생성 프로세스에서 중복된 제목의 뉴스가 제거됩니다.
  * 뉴스 생성 성공 시 반환 데이터가 간소화되었습니다.

* **설정 변경**
  * 네이버 뉴스 API에서 표시되는 뉴스 개수가 3개에서 1개로 변경되었습니다.

* **기타**
  * 실제 뉴스 제목의 데이터베이스 중복 제약 조건이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->