### PR TITLE
[feat] 오늘의 뉴스는 오늘의 뉴스를 통해서만 조회되도록 변경

### DIFF
--- a/src/main/java/com/back/domain/news/common/test/controller/TestController.java
+++ b/src/main/java/com/back/domain/news/common/test/controller/TestController.java
@@ -11,6 +11,9 @@ import com.back.domain.news.real.service.AdminNewsService;
 import com.back.domain.news.real.service.NewsDataService;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -62,6 +65,18 @@ public class TestController {
             log.error("Cleanup failed: {}", e.getMessage());
             return new RsData<>(500, "Cleanup failed", null);
         }
+    }
+
+    //뉴스 생성 (for test)
+    @PostMapping("/create")
+    public RsData<List<RealNewsDto>> createRealNews(@RequestParam String query) {
+        List<RealNewsDto> realNewsList = newsDataService.createRealNewsDto(query);
+
+        if (realNewsList.isEmpty()) {
+            return RsData.of(404, String.format("'%s' 검색어로 뉴스를 찾을 수 없습니다", query));
+        }
+
+        return RsData.of(200, String.format("뉴스 %d건 생성 완료",realNewsList.size()), realNewsList);
     }
 
     @PostMapping("/create/fake")

--- a/src/main/java/com/back/domain/news/common/test/controller/TestController.java
+++ b/src/main/java/com/back/domain/news/common/test/controller/TestController.java
@@ -7,6 +7,7 @@ import com.back.domain.news.common.service.KeywordGenerationService;
 import com.back.domain.news.fake.dto.FakeNewsDto;
 import com.back.domain.news.fake.service.FakeNewsService;
 import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.AdminNewsService;
 import com.back.domain.news.real.service.NewsDataService;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.global.rsData.RsData;
@@ -27,11 +28,26 @@ public class TestController {
     private final FakeNewsService fakeNewsService;
     private final RealNewsService realNewsService;
     private final NewsDataService newsDataService;
+    private final AdminNewsService adminNewsService;
 
     @GetMapping("/keywords")
     public KeywordGenerationResDto testKeywords() {
         return keywordGenerationService.generateTodaysKeywords();
     }
+
+
+    //     뉴스 배치 프로세서
+    @GetMapping("/process")
+    public RsData<Void> newsProcess() {
+        try {
+            adminNewsService.dailyNewsProcess();
+
+            return RsData.of(200, "성공");
+        } catch (Exception e) {
+            return RsData.of(500, "실패: " + e.getMessage());
+        }
+    }
+
 
     //-1 -> 내일 이전(모든 키워드 삭제)
     // 0 -> 오늘 이전(어제 키워드까지 삭제)

--- a/src/main/java/com/back/domain/news/fake/service/AdminFakeNewsService.java
+++ b/src/main/java/com/back/domain/news/fake/service/AdminFakeNewsService.java
@@ -1,0 +1,47 @@
+package com.back.domain.news.fake.service;
+
+import com.back.domain.news.fake.dto.FakeNewsDto;
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.RealNewsService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminFakeNewsService {
+
+    private final FakeNewsService fakeNewsService;
+    private final RealNewsService realNewsService;
+
+
+    @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시에 실행
+    public void dailyFakeNewsProcess() {
+        try {
+            List<RealNewsDto> realNewsDtos = realNewsService.getRealNewsListCreatedToday();
+
+            if (realNewsDtos == null || realNewsDtos.isEmpty()) {
+                log.warn("오늘 생성된 실제 뉴스가 없습니다.");
+                return;
+            }
+            log.info("처리 대상 실제 뉴스: {}개", realNewsDtos.size());
+
+            List<FakeNewsDto> fakeNewsDtos = fakeNewsService.generateAndSaveAllFakeNews(realNewsDtos);
+
+            log.info("=== 일일 가짜뉴스 생성 배치 완료 ===");
+            log.info("요청: {}개, 성공: {}개, 실패: {}개",
+                    realNewsDtos.size(),
+                    fakeNewsDtos.size(),
+                    realNewsDtos.size() - fakeNewsDtos.size());
+
+        } catch (ServiceException e) {
+            log.error("가짜 뉴스 생성 중 오류 발생: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -63,11 +63,11 @@ public class AdminNewsController {
     @GetMapping("/process")
     public RsData<List<RealNewsDto>> newsProcess() {
         try {
-            List<RealNewsDto> result = adminNewsService.dailyNewsProcess();
+            adminNewsService.dailyNewsProcess();
 
-            return RsData.of(200, "성공", result);
+            return RsData.of(200, "뉴스 생성 성공");
         } catch (Exception e) {
-            return RsData.of(500, "실패: " + e.getMessage());
+            return RsData.of(500, "뉴스 생성 실패 : " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -4,9 +4,11 @@ import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.mapper.RealNewsMapper;
+import com.back.domain.news.real.repository.TodayNewsRepository;
 import com.back.domain.news.real.service.RealNewsService;
 import com.back.domain.news.common.service.NewsPageService;
 import com.back.domain.news.common.enums.NewsType;
+import com.back.domain.news.today.entity.TodayNews;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -38,7 +41,7 @@ public class RealNewsController {
 
     private final RealNewsService realNewsService;
     private final NewsPageService newsPageService;
-
+    private final TodayNewsRepository todayNewsRepository;
 
     //단건조회
     @Operation(summary = "단건 뉴스 조회", description = "ID로 단건 뉴스를 조회합니다.")
@@ -56,13 +59,19 @@ public class RealNewsController {
             return RsData.of(400, "잘못된 뉴스 ID입니다. 1 이상의 숫자를 입력해주세요.");
         }
 
+        Optional<Long> todayNewsId = realNewsService.getTodayNews()
+                .map(RealNewsDto::id);
+
+        if (todayNewsId.isPresent() && newsId.equals(todayNewsId.get())) {
+            return RsData.of(403, "오늘의 뉴스는 탭을 통해 조회해주세요.");
+        }
+
         Optional<RealNewsDto> realNewsDto = realNewsService.getRealNewsDtoById(newsId);
 
         if (realNewsDto.isEmpty()) {
             return RsData.of(404,
                     String.format("ID %d에 해당하는 뉴스를 찾을 수 없습니다. 올바른 뉴스 ID인지 확인해주세요.", newsId));
         }
-
 
         return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, newsId);
     }

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -30,7 +30,6 @@ public class RealNews {
     @GeneratedValue(strategy = IDENTITY)
     private long id;
 
-    @Column(unique = true)
     private String title;
 
     @Lob

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -24,5 +24,11 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     List<RealNews> findByOriginCreatedDateBetween(LocalDateTime start, LocalDateTime end);
 
     Page<RealNews> findByNewsCategory(NewsCategory category, Pageable pageable);
+
+    Page<RealNews> findByTitleContainingAndIdNot(String title, Long excludeId, Pageable pageable);
+
+    Page<RealNews> findByIdNot(Long excludeId, Pageable pageable);
+
+    Page<RealNews> findByNewsCategoryAndIdNot(NewsCategory category, Long excludeId, Pageable pageable);
 }
 

--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -2,41 +2,17 @@ package com.back.domain.news.real.service;
 
 import com.back.domain.news.common.dto.AnalyzedNewsDto;
 import com.back.domain.news.common.dto.NaverNewsDto;
-import com.back.domain.news.common.dto.NewsDetailDto;
-import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.common.service.KeywordGenerationService;
 import com.back.domain.news.common.service.NewsAnalysisService;
 import com.back.domain.news.real.dto.RealNewsDto;
-import com.back.domain.news.real.entity.RealNews;
-import com.back.domain.news.real.mapper.RealNewsMapper;
-import com.back.domain.news.real.repository.RealNewsRepository;
-import com.back.domain.news.real.repository.TodayNewsRepository;
-import com.back.domain.news.today.entity.TodayNews;
-import com.back.global.exception.ServiceException;
-import com.back.global.util.HtmlEntityDecoder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -50,20 +26,22 @@ public class AdminNewsService {
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
-    public List<RealNewsDto> dailyNewsProcess(){
+    public void dailyNewsProcess(){
         List<String> keywords = keywordGenerationService.generateTodaysKeywords().getKeywords();
         //   속보랑 기타키워드 추가
-        List<String> additionalKeywords = newsDataService.addKeywords(keywords, STATIC_KEYWORD);
+        List<String> newsKeywords = newsDataService.addKeywords(keywords, STATIC_KEYWORD);
 
-        List<NaverNewsDto> allNews = newsDataService.collectMetaDataFromNaver(keywords);
+        List<NaverNewsDto> newsKeywordsAfterAdd = newsDataService.collectMetaDataFromNaver(newsKeywords);
 
-        List<RealNewsDto> allRealNewsBeforeFilter = newsDataService.createRealNewsDtoByCrawl(allNews);
+        List<RealNewsDto> NewsBeforeFilter = newsDataService.createRealNewsDtoByCrawl(newsKeywordsAfterAdd);
 
-        List<AnalyzedNewsDto> allRealNewsAfterFilter = newsAnalysisService.filterAndScoreNews(allRealNewsBeforeFilter);
+        List<RealNewsDto> NewsRemovedDuplicateTitles = newsDataService.removeDuplicateTitles(NewsBeforeFilter);
 
-        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(allRealNewsAfterFilter);
+        List<AnalyzedNewsDto> newsAfterFilter = newsAnalysisService.filterAndScoreNews(NewsRemovedDuplicateTitles);
 
-        return newsDataService.saveAllRealNews(selectedNews);
+        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(newsAfterFilter);
+
+        List<RealNewsDto> savedNews = newsDataService.saveAllRealNews(selectedNews);
     }
 
 }

--- a/src/main/java/com/back/domain/news/real/service/NewsDataService.java
+++ b/src/main/java/com/back/domain/news/real/service/NewsDataService.java
@@ -24,6 +24,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -397,4 +399,11 @@ public class NewsDataService {
         }
         return new ArrayList<>(uniqueNewsMap.values());
     }
+
+    @Transactional(readOnly = true)
+    public Page<RealNewsDto> getAllRealNewsList(Pageable pageable) {
+        return realNewsRepository.findAll(pageable)
+                .map(realNewsMapper::toDto);
+    }
+
 }

--- a/src/main/java/com/back/domain/news/real/service/NewsDataService.java
+++ b/src/main/java/com/back/domain/news/real/service/NewsDataService.java
@@ -388,4 +388,13 @@ public class NewsDataService {
                 .distinct()
                 .toList();
     }
+
+    public List<RealNewsDto> removeDuplicateTitles(List<RealNewsDto> newsBeforeFilter) {
+        // 제목을 기준으로 중복 제거
+        Map<String, RealNewsDto> uniqueNewsMap = new LinkedHashMap<>();
+        for (RealNewsDto news : newsBeforeFilter) {
+            uniqueNewsMap.put(news.title(), news);
+        }
+        return new ArrayList<>(uniqueNewsMap.values());
+    }
 }

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -60,6 +60,7 @@ public class RealNewsService {
         LocalDateTime start = LocalDate.now().atStartOfDay(); // 오늘 00:00
         LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
 
+//아이디순 정렬할것
         List<RealNews> realNewsList = realNewsRepository.findByOriginCreatedDateBetween(start, end);
         return realNewsList.stream()
                 .map(realNewsMapper::toDto)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   base-url: "https://openapi.naver.com/v1/search/news?query="
   news:
-    display: 3
+    display: 1
     sort: sim
   crawling:
     delay: 1000 # 줄이지 말아주세요


### PR DESCRIPTION
## 📢 기능 설명

- 관리자용 모든 메뉴 조회 api 구현
- 페이징, 직접검색을 통한 오늘의 뉴스 조회 x

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #152
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
