### PR TITLE
[feat] 팩트체크 퀴즈 풀이 구현 + 멤버마다 퀴즈 풀이 내역 리팩토링

### DIFF
--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,7 +1,6 @@
 package com.back.domain.member.member.entity;
 
 import com.back.domain.member.quizhistory.entity.QuizHistory;
-import com.back.domain.quiz.QuizType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
@@ -56,22 +55,8 @@ public class Member {
 
     // 유저가 푼 퀴즈 기록을 저장하는 리스트 일단 엔티티 없어서 주석
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
-    @Builder.Default
     private List<QuizHistory> quizHistories = new ArrayList<>(); //유저가 퀴즈를 푼 기록
 
-    public QuizHistory addQuizHistory(Long quizId, QuizType quizType, String answer, boolean isCorrect, int gainExp) {
-        QuizHistory history = QuizHistory.builder()
-                .quizId(quizId)
-                .quizType(quizType)
-                .answer(answer)
-                .isCorrect(isCorrect)
-                .gainExp(gainExp)
-                .build();
-
-        history.setMember(this);        // 연관관계 주인 설정
-        quizHistories.add(history);     // 정답 리스트에 추가
-        return history;
-    }
 
     public Member(long id, String email, String name) {
         setId(id);

--- a/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
+++ b/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
@@ -8,4 +8,7 @@ import java.util.List;
 
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
     List<QuizHistory> findAllByMemberOrderByCreatedDateDesc(Member actor);
+    List<QuizHistory> findByMemberOrderByCreatedDateDesc(Member actor);
+
+    List<QuizHistory> findByMember(Member actor);
 }

--- a/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
+++ b/src/main/java/com/back/domain/member/quizhistory/service/QuizHistoryService.java
@@ -11,6 +11,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -21,11 +22,10 @@ public class QuizHistoryService {
 
     @Transactional(readOnly = true)
     public List<QuizHistoryDto> getQuizHistoriesByMember(Member actor) {
-        // Member의 quizHistories 리스트를 바로 가져오기 (Lazy라면 강제로 초기화 필요)
-        List<QuizHistory> quizHistories = actor.getQuizHistories();
+        List<QuizHistory> quizHistories = quizHistoryRepository.findByMember(actor);
 
-        // 필요하면 정렬 - createdDate 내림차순으로 정렬
-        quizHistories.sort((a, b) -> b.getCreatedDate().compareTo(a.getCreatedDate()));
+        quizHistories.sort(Comparator.comparing(QuizHistory::getQuizType)); // 퀴즈타입별 정렬
+
 
         return quizHistories.stream()
                 .map(QuizHistoryDto::new)

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -1,10 +1,15 @@
 package com.back.domain.quiz.fact.controller;
 
+import com.back.domain.member.member.entity.Member;
 import com.back.domain.news.common.enums.NewsCategory;
+import com.back.domain.quiz.fact.dto.FactQuizAnswerDto;
 import com.back.domain.quiz.fact.dto.FactQuizDto;
 import com.back.domain.quiz.fact.dto.FactQuizDtoWithNewsContent;
+import com.back.domain.quiz.fact.entity.CorrectNewsType;
 import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.service.FactQuizService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -14,6 +19,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +34,7 @@ import static java.util.stream.Collectors.toList;
 @Tag(name= "FactQuizController", description = "팩트 퀴즈(진짜가짜 퀴즈) 관련 API")
 public class FactQuizController {
     private final FactQuizService factQuizService;
+    private final Rq rq;
 
     @Operation(summary = "팩트 퀴즈 전체 조회", description = "팩트 퀴즈 (전체) 목록을 조회합니다.")
     @ApiResponses(
@@ -114,5 +122,29 @@ public class FactQuizController {
         return RsData.of(
                 200,
                 "팩트 퀴즈 삭제 성공. ID: " + id);
+    }
+
+    @Operation(summary = "팩트 체크 퀴즈 정답 제출", description = """
+                                                    팩트 체크 퀴즈 ID로 팩트 체크 퀴즈의 정답을 제출합니다.
+                                                    데이터 보낼시 프론트에서 타입을 보내줘야합니다 
+                                                    {
+                                                        "selectedNewsType": "REAL" 또는 "FAKE"
+                                                    }
+                                                    """ )
+    @PostMapping("/submit/{id}")
+    public RsData<FactQuizAnswerDto> submitFactQuizAnswer(@PathVariable Long id, @RequestBody @Valid @NotNull CorrectNewsType selectedNewsType) {
+
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        FactQuizAnswerDto submittedQuiz = factQuizService.submitDetailQuizAnswer(actor,id, selectedNewsType);
+
+        return new RsData<>(
+                200,
+                "퀴즈 정답 제출 성공",
+                submittedQuiz
+        );
     }
 }

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizAnswerDto.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizAnswerDto.java
@@ -1,0 +1,21 @@
+package com.back.domain.quiz.fact.dto;
+
+import com.back.domain.quiz.QuizType;
+import com.back.domain.quiz.fact.entity.CorrectNewsType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FactQuizAnswerDto {
+    private Long quizId;
+    private String question; //
+    private CorrectNewsType selectedNewsType; // 사용자가 선택한 뉴스 타입 (REAL, FAKE)
+    private CorrectNewsType correctNewsType; // 정답 뉴스 타입 (REAL, FAKE)
+
+    boolean isCorrect; // 정답 여부
+    int gainExp; // 경험치 획득량
+    private QuizType quizType; // 퀴즈 타입
+}

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -65,6 +65,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
         // 아래 API 요청이면 인증 필수 (추후 진짜 api로 변경 예정)
         if (
+                !uri.startsWith("/api/histories") &&
                 !uri.startsWith("/api/quiz/detail/") && // 상세퀴즈 관련된 모든 요청
                         !uri.startsWith("/api/quiz/fact/") && // OX 퀴즈 단건 조회
                         !uri.startsWith("/ox퀴즈제출") &&


### PR DESCRIPTION
## 📢 기능 설명

팩트체크 퀴즈 풀이 구현
ex) 문제)  다음중 진짜 뉴스는?
   진짜 뉴스     ,      가짜 뉴스 

사용자가 진짜 뉴스를 클릭하면 프론트에서 REAL타입을 보내줘야합니다
반대로 가짜 뉴스를 클릭하면 FAKE타입을 보내줘야합니다.


현재 로그인한 사용자의 풀이 내역 조회 가능 

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #150 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
