### PR TITLE
refactor : 상세 퀴즈 도메인 수정

### DIFF
--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -32,24 +32,6 @@ public class DetailQuizController {
     private final DetailQuizService detailQuizService;
     private final Rq rq;
 
-    // 상세 퀴즈 목록 조회(전체 조회)
-    @Operation(summary = "전체 조회", description = "상세 퀴즈 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "상세 퀴즈 전체 조회 성공"),
-    })
-    @GetMapping
-    public RsData<List<DetailQuizResDto>> getDetailQuizzes() {
-        List<DetailQuiz> detailQuizzes = detailQuizService.findAll();
-
-        return new RsData<>(
-                200,
-                "상세 퀴즈 목록 조회 성공",
-                detailQuizzes.stream()
-                        .map(DetailQuizResDto::new)
-                        .toList()
-        );
-    }
-
     // 상세 퀴즈 단건 조회(퀴즈 ID로 조회)
     @Operation(summary = "단건 조회", description = "퀴즈 ID로 상세 퀴즈를 조회합니다.")
     @ApiResponses(value = {
@@ -82,8 +64,8 @@ public class DetailQuizController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = RsData.class),
                             examples = {
-                                    @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 id의 뉴스가 존재하지 않습니다. id: \", \"data\": null}"),
-                                    @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: \", \"data\": null}")
+                                    @ExampleObject(name = "뉴스 없음", value = "{\"resultCode\": 404, \"msg\": \"해당 id의 뉴스가 존재하지 않습니다. id: \", \"data\": null}"),
+                                    @ExampleObject(name = "퀴즈 없음", value = "{\"resultCode\": 404, \"msg\": \"해당 뉴스에 대한 상세 퀴즈가 존재하지 않습니다. newsId: \", \"data\": null}")
                             }
                     )
             )}

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.java
@@ -38,11 +38,6 @@ public class DetailQuizService {
     }
 
     @Transactional(readOnly = true)
-    public List<DetailQuiz> findAll() {
-        return detailQuizRepository.findAll();
-    }
-
-    @Transactional(readOnly = true)
     public DetailQuiz findById(Long id) {
         return detailQuizRepository.findById(id)
                 .orElseThrow(() -> new ServiceException(404, "해당 id의 상세 퀴즈가 존재하지 않습니다. id: " + id));

--- a/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
@@ -63,25 +63,6 @@ class DetailQuizControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/quiz/detail - 상세 퀴즈 목록 조회")
-    void t1() throws Exception {
-        //Given
-        int quizCount = (int) detailQuizService.count();
-
-        //When
-        ResultActions resultActions = mvc.perform(get("/api/quiz/detail")
-        ).andDo(print());
-
-        //Then
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(handler().methodName("getDetailQuizzes"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("상세 퀴즈 목록 조회 성공"))
-                .andExpect(jsonPath("$.data.length()").value(quizCount));
-    }
-
-    @Test
     @DisplayName("GET /api/quiz/detail/{id} - 상세 퀴즈 단건 조회 성공")
     void t2() throws Exception {
         //Given


### PR DESCRIPTION
## 📢 기능 설명
- getDetailQuizzesByNewsId()의 api 문서에 응답이 제대로 출력되지 않던 부분 수정
- 사용하지 않는 전체 조회 api 삭제

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #165 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상세 퀴즈 전체 목록을 조회하는 엔드포인트가 제거되었습니다.

* **문서화**
  * 상세 퀴즈 조회 시 404 오류 예시의 설명이 추가되어, 오류 상황을 더 명확하게 안내합니다.

* **테스트**
  * 상세 퀴즈 전체 목록 조회 관련 테스트가 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->