### PR TITLE
[feat] 퀴즈 정답 제출 테스트 추가 및 security filter비활성화

### DIFF
--- a/src/test/java/com/back/backend/domain/quiz/daily/controller/DailyQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/daily/controller/DailyQuizControllerTest.java
@@ -4,7 +4,6 @@ import com.back.backend.global.config.TestRqConfig;
 import com.back.backend.global.rq.TestRq;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
-import com.back.domain.quiz.detail.entity.Option;
 import com.back.domain.quiz.detail.service.DetailQuizService;
 import com.back.global.rq.Rq;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,11 +24,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @ActiveProfiles("test")
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @Transactional
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
@@ -109,12 +106,11 @@ public class DailyQuizControllerTest {
     void t3() throws Exception {
         // Given
         Long quizId = 1L;
-        Option selectedOption = Option.OPTION2;
+        String selectedOption = "OPTION2";
 
         // When
         ResultActions resultActions = mvc.perform(post("/api/quiz/daily/submit/{id}", quizId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(selectedOption)))
+                        .param("selectedOption", selectedOption))
                 .andDo(print());
 
         // Then
@@ -135,12 +131,11 @@ public class DailyQuizControllerTest {
     void t4() throws Exception {
         // Given
         Long quizId = 1L;
-        Option selectedOption = Option.OPTION1;
+        String selectedOption = "OPTION1";
 
         // When
         ResultActions resultActions = mvc.perform(post("/api/quiz/daily/submit/{id}", quizId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(selectedOption)))
+                        .param("selectedOption", selectedOption))
                 .andDo(print());
 
         // Then

--- a/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @Transactional
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
@@ -210,12 +210,11 @@ class DetailQuizControllerTest {
     void t9() throws Exception {
         // Given
         Long quizId = 1L;
-        Option selectedOption = Option.OPTION2;
+        String selectedOption = "OPTION2";
 
         // When
         ResultActions resultActions = mvc.perform(post("/api/quiz/detail/submit/{id}", quizId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(selectedOption)))
+                        .param("selectedOption", selectedOption))
                 .andDo(print());
 
         // Then
@@ -236,12 +235,11 @@ class DetailQuizControllerTest {
     void t10() throws Exception {
         // Given
         Long quizId = 1L;
-        Option selectedOption = Option.OPTION1;
+        String selectedOption = "OPTION1";
 
         // When
         ResultActions resultActions = mvc.perform(post("/api/quiz/detail/submit/{id}", quizId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(selectedOption)))
+                        .param("selectedOption", selectedOption))
                 .andDo(print());
 
         // Then

--- a/src/test/java/com/back/backend/domain/quiz/fact/controller/FactQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/fact/controller/FactQuizControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles("test")
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @Transactional
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
@@ -197,5 +197,31 @@ public class FactQuizControllerTest {
                 .andExpect(handler().methodName("deleteFactQuiz"))
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("팩트 퀴즈를 찾을 수 없습니다. ID: " + quizId));
+    }
+
+    @Test
+    @DisplayName("POST /api/quiz/fact/submit/{id} - 퀴즈 정답 제출")
+    void t8() throws Exception {
+        // Given
+        Long quizId = 1L;
+        String selectedNewsType = "REAL";
+
+        // When
+        ResultActions resultActions = mvc.perform(post("/api/quiz/fact/submit/{id}", quizId)
+                        .param("selectedNewsType", selectedNewsType))
+                .andDo(print());
+
+        // Then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().methodName("submitFactQuizAnswer"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("퀴즈 정답 제출 성공"))
+                .andExpect(jsonPath("$.data.quizId").value(quizId))
+                .andExpect(jsonPath("$.data.selectedNewsType").value("REAL"))
+                .andExpect(jsonPath("$.data.correctNewsType").exists())
+                .andExpect(jsonPath("$.data.correct").isBoolean())
+                .andExpect(jsonPath("$.data.gainExp").isNumber())
+                .andExpect(jsonPath("$.data.quizType").value("FACT"));
     }
 }


### PR DESCRIPTION
## 📢 기능 설명
- 퀴즈 도메인에 추가된 정답 제출 메서드 테스트 추가
- 기능 테스트를 위해 테스트에서 security filter 비활성화(@AutoConfigureMockMvc(addFilters = false))

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #169 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 보안 필터를 비활성화하여 테스트 환경을 단순화했습니다.
  * 일부 퀴즈 제출 테스트에서 선택 옵션 전달 방식을 JSON 본문에서 요청 파라미터로 변경했습니다.
  * 팩트 퀴즈 제출 엔드포인트에 대한 신규 테스트가 추가되어 응답 데이터와 동작을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->