### PR TITLE
[refactor] 3개의 퀴즈를 풀면 반환 하는 데이터 추가 #1

### DIFF
--- a/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
+++ b/src/main/java/com/back/domain/member/quizhistory/entity/QuizHistory.java
@@ -39,7 +39,7 @@ public class QuizHistory {
     QuizType quizType; // 퀴즈 타입(3가지)
 
     @Column(nullable = false)
-    private long quizId; // 퀴즈 ID
+    private Long quizId; // 퀴즈 ID
 
     @CreatedDate
     @Setter(AccessLevel.PRIVATE)

--- a/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
+++ b/src/main/java/com/back/domain/member/quizhistory/repository/QuizHistoryRepository.java
@@ -2,13 +2,14 @@ package com.back.domain.member.quizhistory.repository;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.domain.quiz.QuizType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Set;
 
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
-    List<QuizHistory> findAllByMemberOrderByCreatedDateDesc(Member actor);
-    List<QuizHistory> findByMemberOrderByCreatedDateDesc(Member actor);
 
     List<QuizHistory> findByMember(Member actor);
+    List<QuizHistory> findByMemberAndQuizTypeAndQuizIdIn(Member member, QuizType quizType, Set<Long> quizIds);
 }

--- a/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
+++ b/src/main/java/com/back/domain/quiz/daily/controller/DailyQuizController.java
@@ -2,8 +2,7 @@ package com.back.domain.quiz.daily.controller;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.quiz.daily.dto.DailyQuizAnswerDto;
-import com.back.domain.quiz.daily.dto.DailyQuizDto;
-import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.back.domain.quiz.daily.dto.DailyQuizWithHistoryDto;
 import com.back.domain.quiz.daily.service.DailyQuizService;
 import com.back.domain.quiz.detail.entity.Option;
 import com.back.global.exception.ServiceException;
@@ -42,14 +41,20 @@ public class DailyQuizController {
             }
     )
     @GetMapping("/{todayNewsId}")
-    public RsData<List<DailyQuizDto>> getDailyQuizzes(@PathVariable Long todayNewsId) {
-        List<DailyQuiz> dailyQuizzes = dailyQuizService.getDailyQuizzes(todayNewsId);
-        return RsData.of(
+    public RsData<List<DailyQuizWithHistoryDto>> getDailyQuizzes(@PathVariable Long todayNewsId) {
+
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        List<DailyQuizWithHistoryDto> dailyQuizzes = dailyQuizService.getDailyQuizzes(todayNewsId, actor);
+
+        return new RsData<>(
                 200,
                 "오늘의 퀴즈 조회 성공",
-                dailyQuizzes.stream()
-                        .map(DailyQuizDto::new)
-                        .toList()
+                        dailyQuizzes
         );
     }
 

--- a/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizWithHistoryDto.java
+++ b/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizWithHistoryDto.java
@@ -1,0 +1,27 @@
+package com.back.domain.quiz.daily.dto;
+
+import com.back.domain.quiz.QuizType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DailyQuizWithHistoryDto {
+    private List<DailyQuizDto> dailyQuizDto; //원래줄꺼
+
+    private String answer;// 사용자가 선택한 답변
+    boolean isCorrect; //정답 여부
+    int gainExp; // 경험치 획득량
+    private QuizType quizType;
+
+    public DailyQuizWithHistoryDto(List<DailyQuizDto> dailyQuizDto, String answer, boolean isCorrect, int gainExp, QuizType quizType) {
+        this.dailyQuizDto = dailyQuizDto;
+        this.answer = answer;
+        this.isCorrect = isCorrect;
+        this.gainExp = gainExp;
+        this.quizType = quizType;
+    }
+
+}

--- a/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizWithHistoryDto.java
+++ b/src/main/java/com/back/domain/quiz/daily/dto/DailyQuizWithHistoryDto.java
@@ -4,19 +4,17 @@ import com.back.domain.quiz.QuizType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 public class DailyQuizWithHistoryDto {
-    private List<DailyQuizDto> dailyQuizDto; //원래줄꺼
+    private DailyQuizDto dailyQuizDto;
 
     private String answer;// 사용자가 선택한 답변
     boolean isCorrect; //정답 여부
     int gainExp; // 경험치 획득량
     private QuizType quizType;
 
-    public DailyQuizWithHistoryDto(List<DailyQuizDto> dailyQuizDto, String answer, boolean isCorrect, int gainExp, QuizType quizType) {
+    public DailyQuizWithHistoryDto(DailyQuizDto dailyQuizDto, String answer, boolean isCorrect, int gainExp, QuizType quizType) {
         this.dailyQuizDto = dailyQuizDto;
         this.answer = answer;
         this.isCorrect = isCorrect;

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -23,7 +23,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +50,8 @@ public class DailyQuizService {
         //이제 여기서 퀴즈 저장소에서 memberid로 퀴즈 히스토리를 가져와야 함
         List<QuizHistory> quizHistories = quizHistoryRepository.findByMember(actor);
 
+
+
         // 1. 기준이 되는 DailyQuiz 리스트에서 ID만 추출
         Set<Long> quizIdSet = quizzes.stream()
                 .map(DailyQuiz::getId)
@@ -69,7 +70,7 @@ public class DailyQuizService {
                 .map(quiz -> {
                     QuizHistory history = historyMap.get(quiz.getId());
                     return new DailyQuizWithHistoryDto(
-                            Collections.singletonList(new DailyQuizDto(quiz)),
+                            (new DailyQuizDto(quiz)),
                             history != null ? history.getAnswer() : null,
                             history != null && history.isCorrect(),
                             history != null ? history.getGainExp() : 0,

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -2,11 +2,16 @@ package com.back.domain.quiz.daily.service;
 
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.back.domain.member.quizhistory.repository.QuizHistoryRepository;
 import com.back.domain.member.quizhistory.service.QuizHistoryService;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.repository.TodayNewsRepository;
 import com.back.domain.news.today.entity.TodayNews;
+import com.back.domain.quiz.QuizType;
 import com.back.domain.quiz.daily.dto.DailyQuizAnswerDto;
+import com.back.domain.quiz.daily.dto.DailyQuizDto;
+import com.back.domain.quiz.daily.dto.DailyQuizWithHistoryDto;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.repository.DailyQuizRepository;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
@@ -18,7 +23,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,14 +37,48 @@ public class DailyQuizService {
     private final TodayNewsRepository todayNewsRepository;
     private final MemberRepository memberRepository;
     private final QuizHistoryService quizHistoryService;
+    private final QuizHistoryRepository quizHistoryRepository;
 
     @Transactional(readOnly = true)
-    public List<DailyQuiz> getDailyQuizzes(Long todayNewsId) {
+    public List<DailyQuizWithHistoryDto> getDailyQuizzes(Long todayNewsId, Member actor) {
+        //퀴즈 가져오기
         List<DailyQuiz> quizzes = dailyQuizRepository.findByTodayNewsId(todayNewsId);
+
         if( quizzes.isEmpty()) {
             throw new ServiceException(404, "오늘의 뉴스에 해당하는 오늘의 퀴즈가 존재하지 않습니다.");
         }
-        return quizzes;
+
+        //이제 여기서 퀴즈 저장소에서 memberid로 퀴즈 히스토리를 가져와야 함
+        List<QuizHistory> quizHistories = quizHistoryRepository.findByMember(actor);
+
+        // 1. 기준이 되는 DailyQuiz 리스트에서 ID만 추출
+        Set<Long> quizIdSet = quizzes.stream()
+                .map(DailyQuiz::getId)
+                .collect(Collectors.toSet());
+
+        // 2. 퀴즈 히스토리 중에서 quizId가 일치하고, 타입이 DAILY인 것만 필터링
+        List<QuizHistory> filteredHistories = quizHistories.stream()
+                .filter(h -> h.getQuizType() == QuizType.DAILY && quizIdSet.contains(h.getQuizId()))
+                .toList();
+
+        Map<Long, QuizHistory> historyMap = filteredHistories.stream()
+                .collect(Collectors.toMap(QuizHistory::getQuizId, h -> h));
+
+        // 3. DailyQuizWithHistoryDto로 변환
+        List<DailyQuizWithHistoryDto> result = quizzes.stream()
+                .map(quiz -> {
+                    QuizHistory history = historyMap.get(quiz.getId());
+                    return new DailyQuizWithHistoryDto(
+                            Collections.singletonList(new DailyQuizDto(quiz)),
+                            history != null ? history.getAnswer() : null,
+                            history != null && history.isCorrect(),
+                            history != null ? history.getGainExp() : 0,
+                            QuizType.DAILY
+                    );
+                })
+                .toList();
+
+        return result;
     }
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")

--- a/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
+++ b/src/main/java/com/back/domain/quiz/detail/controller/DetailQuizController.java
@@ -4,6 +4,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.quiz.detail.dto.DetailQuizAnswerDto;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
 import com.back.domain.quiz.detail.dto.DetailQuizResDto;
+import com.back.domain.quiz.detail.dto.DetailQuizWithHistoryDto;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
 import com.back.domain.quiz.detail.entity.Option;
 import com.back.domain.quiz.detail.service.DetailQuizService;
@@ -45,13 +46,20 @@ public class DetailQuizController {
             )}
     )
     @GetMapping("/{id}")
-    public RsData<DetailQuizResDto> getDetailQuiz(@PathVariable Long id) {
-        DetailQuiz detailQuiz = detailQuizService.findById(id);
+    public RsData<DetailQuizWithHistoryDto> getDetailQuiz(@PathVariable Long id) {
+
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        DetailQuizWithHistoryDto detailQuiz = detailQuizService.findById(id,actor);
 
         return new RsData<>(
                 200,
                 "상세 퀴즈 조회 성공",
-                new DetailQuizResDto(detailQuiz)
+                detailQuiz
         );
     }
 

--- a/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizWithHistoryDto.java
+++ b/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizWithHistoryDto.java
@@ -24,6 +24,4 @@ public class DetailQuizWithHistoryDto {
         this.quizType = quizType;
     }
 
-    public DetailQuizWithHistoryDto(DetailQuizResDto detailQuizResDto, String answer, Object o) {
-    }
 }

--- a/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizWithHistoryDto.java
+++ b/src/main/java/com/back/domain/quiz/detail/dto/DetailQuizWithHistoryDto.java
@@ -1,0 +1,29 @@
+package com.back.domain.quiz.detail.dto;
+
+
+import com.back.domain.quiz.QuizType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DetailQuizWithHistoryDto {
+
+    DetailQuizResDto detailQuizResDto; // 상세 퀴즈 정보
+
+    private String answer;// 사용자가 선택한 답변
+    boolean isCorrect; //정답 여부
+    int gainExp; // 경험치 획득량
+    private QuizType quizType;
+
+    public DetailQuizWithHistoryDto(DetailQuizResDto detailQuizResDto, String answer, boolean isCorrect, int gainExp, QuizType quizType) {
+        this.detailQuizResDto = detailQuizResDto;
+        this.answer = answer;
+        this.isCorrect = isCorrect;
+        this.gainExp = gainExp;
+        this.quizType = quizType;
+    }
+
+    public DetailQuizWithHistoryDto(DetailQuizResDto detailQuizResDto, String answer, Object o) {
+    }
+}

--- a/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
+++ b/src/main/java/com/back/domain/quiz/fact/controller/FactQuizController.java
@@ -4,7 +4,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.quiz.fact.dto.FactQuizAnswerDto;
 import com.back.domain.quiz.fact.dto.FactQuizDto;
-import com.back.domain.quiz.fact.dto.FactQuizDtoWithNewsContent;
+import com.back.domain.quiz.fact.dto.FactQuizWithHistoryDto;
 import com.back.domain.quiz.fact.entity.CorrectNewsType;
 import com.back.domain.quiz.fact.entity.FactQuiz;
 import com.back.domain.quiz.fact.service.FactQuizService;
@@ -79,13 +79,20 @@ public class FactQuizController {
                             examples = @ExampleObject(value = "{\"resultCode\": 404, \"msg\": \"팩트 퀴즈를 찾을 수 없습니다. ID: 1\", \"data\": null}"))),
     })
     @GetMapping("/{id}")
-    public RsData<FactQuizDtoWithNewsContent> getFactQuizById(@PathVariable Long id) {
-        FactQuiz factQuiz = factQuizService.findById(id);
+    public RsData<FactQuizWithHistoryDto> getFactQuizById(@PathVariable Long id) {
+
+        Member actor = rq.getActor();
+
+        if (actor == null) {
+            throw new ServiceException(401, "로그인이 필요합니다.");
+        }
+
+        FactQuizWithHistoryDto factQuiz = factQuizService.findById(id,actor);
 
         return new RsData<>(
                 200,
                 "팩트 퀴즈 조회 성공. ID: " + id,
-                new FactQuizDtoWithNewsContent(factQuiz)
+                factQuiz
         );
     }
 

--- a/src/main/java/com/back/domain/quiz/fact/dto/FactQuizWithHistoryDto.java
+++ b/src/main/java/com/back/domain/quiz/fact/dto/FactQuizWithHistoryDto.java
@@ -1,0 +1,24 @@
+package com.back.domain.quiz.fact.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FactQuizWithHistoryDto {
+
+    private FactQuizDtoWithNewsContent factQuizDto; // 퀴즈 정보 (질문, 정답 뉴스 제목 등)
+
+    private String answer; // 사용자가 선택한 답변
+    private boolean isCorrect; // 정답 여부
+    private int gainExp; // 경험치 획득량
+
+    public FactQuizWithHistoryDto(FactQuizDtoWithNewsContent factQuizDto, String answer, boolean isCorrect, int gainExp) {
+        this.factQuizDto = factQuizDto;
+        this.answer = answer;
+        this.isCorrect = isCorrect;
+        this.gainExp = gainExp;
+    }
+
+}


### PR DESCRIPTION
## 📢 기능 설명
daily, detail, fact 퀴즈 단건 요청하면 퀴즈의 정보 + 풀었던 기록까지 나옴


따라서 푼지 안푼지 체크는 answer = null 이면 푼적이없고
answer에 문자가 존재하면 풀었습니다.  ( answer에 데이터가 존재하면 푼기록이 있습니다)



필요시 실행결과 스크린샷 첨부
<br>
(처음 문제를 본상황)

<img width="636" height="364" alt="image" src="https://github.com/user-attachments/assets/d5d62086-60df-4f2f-b7c6-20ceac9da4d9" />


<br>
(문제를 풀었으면)

<img width="725" height="352" alt="image" src="https://github.com/user-attachments/assets/d67636dd-bbb5-45bc-87b5-69c23bbf0ba5" />

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #168 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 데일리, 상세, 팩트 퀴즈 조회 시 사용자의 풀이 이력(정답 여부, 선택 답변, 획득 경험치 등)이 함께 제공됩니다.

* **버그 수정**
  * 퀴즈 이력에서 quizId 필드가 null 값을 가질 수 있도록 개선되었습니다.

* **기타**
  * 퀴즈 조회 API가 로그인된 사용자만 이용할 수 있도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->