### PR TITLE
[fix] DailyQuizService 오류 해결#1

### DIFF
--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizScheduledService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizScheduledService.java
@@ -1,0 +1,16 @@
+package com.back.domain.quiz.daily.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DailyQuizScheduledService {
+    private final DailyQuizService dailyQuizService;
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+    public void scheduleCreateDailyQuiz() {
+        dailyQuizService.createDailyQuiz();
+    }
+}

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -19,7 +19,6 @@ import com.back.domain.quiz.detail.entity.Option;
 import com.back.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,8 +78,7 @@ public class DailyQuizService {
         );
     }
 
-
-    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Transactional
     public void createDailyQuiz() {
         TodayNews todayNews = todayNewsRepository.findFirstByOrderBySelectedDateDesc()
                 .orElseThrow(() -> new ServiceException(404, "오늘의 뉴스가 없습니다."));


### PR DESCRIPTION
## 📢 기능 설명
오류 원인:
@scheduled 메서드는 트랜잭션 범위 밖에서 실행
-> realNews를 가져오는 시점 이후에 세션이 닫히고, 그 상태에서 lazy 컬렉션에 접근하면서 오류 발생

해결:
DailyQuizScheduledServic로 @Scheduled 메서드를 분리, 해당 메서드에서 DailyQuizService의 기존 로직 호출
기존 로직은 DailyQuizService에서 @Transactional을 적용해서 실행

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #179 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매일 오전 1시(서울 시간)에 일일 퀴즈가 자동 생성되도록 예약 기능이 추가되었습니다.

* **버그 수정**
  * 일일 퀴즈 생성 방식이 개선되어, 예약된 시간에만 자동으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->