### PR TITLE
[fix] 상세 퀴즈 생성 로직 수정

### DIFF
--- a/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/AdminNewsService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -53,8 +54,9 @@ public class AdminNewsService {
         }
         newsDataService.setTodayNews(savedNews.getFirst().id());
 
-        List<Long> realNewsIds = selectedNews.stream()
+        List<Long> realNewsIds = savedNews.stream()
                 .map(RealNewsDto::id)
+                .filter(Objects::nonNull) // null 체크
                 .toList();
 
         // 트랜잭션 커밋 이후에 이벤트 발행


### PR DESCRIPTION
## 📢 기능 설명
generateDetailQuizzes()에서 realNewsIds가 전부 null로 들어가 퀴즈가 생성되지 않던 오류를 수정

오류 원인
AdminNewsService의 dailyNewsProcess()에서 이벤트를 발행할 때 DB에 저장되지 않은 상태의 리스트에서 id를 추출해서 넘김

해결
저장된 DTO 리스트인 savedNews에서 id를 추출해 이벤트 발행하도록 로직 수정

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #196 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 저장된 뉴스에서 ID를 추출할 때 null 값을 제외하여, 실제 뉴스 ID 목록에 올바른 값만 포함되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->