### PR TITLE
[refactor] 가짜 뉴스 생성 실패시 default case 반환 및 진짜 뉴스 async 분리하여 비동기 기능 작동하도록 구현

### DIFF
--- a/src/main/java/com/back/domain/news/common/service/AnalysisNewsService.java
+++ b/src/main/java/com/back/domain/news/common/service/AnalysisNewsService.java
@@ -26,12 +26,7 @@ import java.util.concurrent.ExecutionException;
 @RequiredArgsConstructor
 public class AnalysisNewsService {
 
-    private final AiService aiService;
-    private final ObjectMapper objectMapper;
-    private final RateLimiter rateLimiter;
-
-    @Qualifier("bucket")
-    private final Bucket bucket;
+    private final NewsAnalysisBatchService newsAnalysisBatchService;
 
     @Value("${news.filter.batch.size:2}") // 배치 크기 설정, 3으로 하면 본문 길면 깨짐
     private int batchSize;
@@ -57,7 +52,7 @@ public class AnalysisNewsService {
 
         // 비동기 작업들 시작
         List<CompletableFuture<Void>> futures = batches.stream()
-                .map(batch -> processBatchAsync(batch)
+                .map(batch -> newsAnalysisBatchService.processBatchAsync(batch)
                         .thenAccept(result -> {
                             // 완료되는 대로 즉시 결과에 추가
                             allResults.addAll(result);
@@ -84,32 +79,6 @@ public class AnalysisNewsService {
 
         log.info("뉴스 필터링 완료 - 최종 결과: {}개", allResults.size());
         return new ArrayList<>(allResults);
-    }
-
-    @Async("newsExecutor")
-    public CompletableFuture<List<AnalyzedNewsDto>> processBatchAsync(List<RealNewsDto> batch) {
-
-        log.info("스레드: {}, 배치 시작 시간: {}",
-                Thread.currentThread().getName(), System.currentTimeMillis());
-        try {
-            // Rate limiting - 토큰 얻을 때까지 계속 시도
-            rateLimiter.waitForRateLimit();
-            log.debug("배치 처리 시작 - 기사 수: {}", batch.size());
-
-            NewsAnalysisProcessor processor = new NewsAnalysisProcessor(batch, objectMapper);
-            List<AnalyzedNewsDto> result = aiService.process(processor);
-
-            log.debug("배치 처리 완료 - 결과 수: {}", result.size());
-
-            log.info("스레드: {}, 배치 완료 시간: {}",
-                    Thread.currentThread().getName(), System.currentTimeMillis());
-
-            return CompletableFuture.completedFuture(result);
-
-        } catch (Exception e) {
-            log.error("배치 {}개 처리 중 오류 발생", batch.size(), e);
-            return CompletableFuture.completedFuture(List.of()); // AI 처리 실패시만 빈 리스트
-        }
     }
 
 }

--- a/src/main/java/com/back/domain/news/common/service/NewsAnalysisBatchService.java
+++ b/src/main/java/com/back/domain/news/common/service/NewsAnalysisBatchService.java
@@ -1,0 +1,44 @@
+package com.back.domain.news.common.service;
+
+import com.back.domain.news.common.dto.AnalyzedNewsDto;
+import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.global.ai.AiService;
+import com.back.global.ai.processor.NewsAnalysisProcessor;
+import com.back.global.rateLimiter.RateLimiter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsAnalysisBatchService {
+
+    private final AiService aiService;
+    private final ObjectMapper objectMapper;
+    private final RateLimiter rateLimiter;
+
+    @Async("newsExecutor")
+    public CompletableFuture<List<AnalyzedNewsDto>> processBatchAsync(List<RealNewsDto> batch) {
+        log.info("스레드: {}, 배치 시작", Thread.currentThread().getName());
+
+        try {
+            rateLimiter.waitForRateLimit();
+
+            NewsAnalysisProcessor processor = new NewsAnalysisProcessor(batch, objectMapper);
+            List<AnalyzedNewsDto> result = aiService.process(processor);
+
+            log.info("스레드: {}, 배치 완료 - {}개", Thread.currentThread().getName(), result.size());
+            return CompletableFuture.completedFuture(result);
+
+        } catch (Exception e) {
+            log.error("배치 처리 실패", e);
+            return CompletableFuture.completedFuture(List.of());
+        }
+    }
+}

--- a/src/main/java/com/back/domain/news/fake/service/FakeNewsService.java
+++ b/src/main/java/com/back/domain/news/fake/service/FakeNewsService.java
@@ -71,7 +71,7 @@ public class FakeNewsService {
 
                     } catch (Exception e) {
                         log.error("가짜뉴스 생성 실패 - 실제뉴스 ID: {}", realNewsDto.id(), e);
-                        throw new RuntimeException("가짜뉴스 생성 실패", e);
+                        return null;
                     }
                 }, executor)) // ← executor 사용
                 .toList();
@@ -90,6 +90,12 @@ public class FakeNewsService {
     public List<FakeNewsDto> generateAndSaveAllFakeNews(List<RealNewsDto> realNewsDtos){
         try{
             List<FakeNewsDto> fakeNewsDtos = generateFakeNewsBatch(realNewsDtos).get();
+
+            if (fakeNewsDtos.isEmpty()) {
+                log.warn("생성된 가짜뉴스가 없습니다.");
+                return Collections.emptyList();
+            }
+
             saveAllFakeNews(fakeNewsDtos);
 
             return fakeNewsDtos;

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     Page<RealNews> findByTitleContaining(String title, Pageable pageable);

--- a/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
+++ b/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
@@ -165,8 +165,7 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
         String failureContent = String.format(
                 "이 뉴스는 AI 생성에 실패하여 자동으로 생성된 안내문입니다. " +
                 "AI 시스템에서 해당 뉴스의 가짜 버전을 생성하는 중 기술적 오류가 발생했습니다. " +
-                "시스템 관리자에게 문의하시거나 나중에 다시 시도해 주세요.",
-                realNewsDto.title()
+                "시스템 관리자에게 문의하시거나 나중에 다시 시도해 주세요."
         );
 
         return FakeNewsDto.of(realNewsDto.id(), failureContent);

--- a/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
+++ b/src/main/java/com/back/global/ai/processor/FakeNewsGeneratorProcessor.java
@@ -151,14 +151,25 @@ public class FakeNewsGeneratorProcessor implements AiRequestProcessor<FakeNewsDt
 
         } catch (JsonProcessingException e) {
             log.error("JSON 파싱 실패: {}", e.getMessage());
-            throw new ServiceException(500, "AI 응답의 JSON 형식이 올바르지 않습니다: " + e.getMessage());
+            return createFailureNotice();
         } catch (IllegalArgumentException e) {
             log.error("데이터 변환 실패: {}", e.getMessage());
-            throw new ServiceException(500, "AI 응답 데이터 변환에 실패했습니다: " + e.getMessage());
+            return createFailureNotice();
         } catch (Exception e) {
             log.error("예상치 못한 오류: {}", e.getMessage());
-            throw new ServiceException(500, "AI 응답 처리 중 예상치 못한 오류가 발생했습니다: " + e.getMessage());
+            return createFailureNotice();
         }
+    }
+
+    private FakeNewsDto createFailureNotice() {
+        String failureContent = String.format(
+                "이 뉴스는 AI 생성에 실패하여 자동으로 생성된 안내문입니다. " +
+                "AI 시스템에서 해당 뉴스의 가짜 버전을 생성하는 중 기술적 오류가 발생했습니다. " +
+                "시스템 관리자에게 문의하시거나 나중에 다시 시도해 주세요.",
+                realNewsDto.title()
+        );
+
+        return FakeNewsDto.of(realNewsDto.id(), failureContent);
     }
     /**
      * AI 응답 정리 - 마크다운 코드 블록만 제거

--- a/src/main/java/com/back/global/async/AsyncConfig.java
+++ b/src/main/java/com/back/global/async/AsyncConfig.java
@@ -26,8 +26,8 @@ public class AsyncConfig {
     @Bean(name = "newsExecutor")
     public Executor newsExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(3); // 동시에 실행할 스레드 수
-        executor.setMaxPoolSize(5);  // 최대 스레드 수
+        executor.setCorePoolSize(2); // 동시에 실행할 스레드 수
+        executor.setMaxPoolSize(2);  // 최대 스레드 수
         executor.setQueueCapacity(50); // 대기 큐 크기
         executor.setThreadNamePrefix("newsGen-");
         executor.setWaitForTasksToCompleteOnShutdown(true); // 종료 시 모든 작업이 완료될 때까지 대기

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   base-url: "https://openapi.naver.com/v1/search/news?query="
   news:
-    display: 4
+    display: 2
     sort: sim
   crawling:
     delay: 1000 # 줄이지 말아주세요


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #203
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 뉴스 분석 기능의 비동기 배치 처리가 별도의 서비스로 분리되어 구조가 개선되었습니다.
  * 내부 의존성이 단일 서비스로 통합되어 유지보수성이 향상되었습니다.

* **Bug Fixes**
  * 가짜 뉴스 생성 시 오류 발생 시 예외 대신 null 또는 실패 안내 메시지로 처리되어, 장애 상황에서도 서비스가 중단되지 않도록 개선되었습니다.
  * 가짜 뉴스 생성 결과가 없을 경우 저장을 시도하지 않고 경고 로그를 남기도록 처리되었습니다.

* **Chores**
  * Naver 뉴스 API에서 표시되는 뉴스 개수가 4개에서 2개로 조정되었습니다.
  * 뉴스 비동기 처리 스레드풀의 크기가 2로 축소되어 시스템 리소스 사용이 최적화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->