### PR TITLE
[refactor] 오늘의 퀴즈 생성 로직에 중복 체크 추가

### DIFF
--- a/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
+++ b/src/main/java/com/back/domain/quiz/daily/repository/DailyQuizRepository.java
@@ -2,6 +2,7 @@ package com.back.domain.quiz.daily.repository;
 
 import com.back.domain.news.today.entity.TodayNews;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.back.domain.quiz.detail.entity.DetailQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,6 @@ public interface DailyQuizRepository extends JpaRepository<DailyQuiz, Long> {
     List<DailyQuiz> findByTodayNewsId(@Param("todayNewsId") Long todayNewsId);
 
     boolean existsByTodayNews(TodayNews todayNews);
+
+    boolean existsByDetailQuiz(DetailQuiz quiz);
 }

--- a/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
+++ b/src/main/java/com/back/domain/quiz/daily/service/DailyQuizService.java
@@ -100,23 +100,16 @@ public class DailyQuizService {
         }
 
         for (DetailQuiz quiz : quizzes) {
-//            boolean alreadyExists = todayNews.getTodayQuizzes().stream()
-//                    .anyMatch(dq -> dq.getDetailQuiz().getId().equals(quiz.getId()));
-//
-//            if (!alreadyExists) {
-//                DailyQuiz dailyQuiz = new DailyQuiz(todayNews, quiz);
-//                todayNews.getTodayQuizzes().add(dailyQuiz);
-//            } else {
-//                log.warn("이미 존재하는 DetailQuiz 기반 DailyQuiz입니다. id = {}", quiz.getId());
-//            }
+            boolean alreadyExists = dailyQuizRepository.existsByDetailQuiz(quiz);
+
+            if (alreadyExists) {
+                log.warn("이미 존재하는 DetailQuiz 기반 DailyQuiz입니다. id = {}", quiz.getId());
+                continue; // 중복이면 건너뜀
+            }
 
             DailyQuiz dailyQuiz = new DailyQuiz(todayNews, quiz);
             todayNews.getTodayQuizzes().add(dailyQuiz);
         }
-    }
-
-    public long count() {
-        return dailyQuizRepository.count();
     }
 
     @Transactional
@@ -139,9 +132,20 @@ public class DailyQuizService {
         }
 
         for (DetailQuiz quiz : quizzes) {
+            boolean alreadyExists = dailyQuizRepository.existsByDetailQuiz(quiz);
+
+            if (alreadyExists) {
+                log.warn("이미 존재하는 DetailQuiz 기반 DailyQuiz입니다. id = {}", quiz.getId());
+                continue; // 중복이면 건너뜀
+            }
+
             DailyQuiz dailyQuiz = new DailyQuiz(todayNews, quiz);
             todayNews.getTodayQuizzes().add(dailyQuiz);
         }
+    }
+
+    public long count() {
+        return dailyQuizRepository.count();
     }
 
     @Transactional

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizRateLimitedService.java
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizRateLimitedService.java
@@ -17,7 +17,7 @@ public class DetailQuizRateLimitedService {
     private final Bucket bucket;
 
     public List<DetailQuizDto> generatedQuizzesWithRateLimit(Long newsId) throws InterruptedException {
-        int maxRetries = 3; // 최대 재시도 횟수
+        int maxRetries = 5; // 최대 재시도 횟수
         int retryDelay = 60000; // 재시도 대기 시간 (밀리초 단위)
 
         for(int i=0; i<maxRetries; i++){


### PR DESCRIPTION
## 📢 기능 설명
중복 저장으로 인한 오류를 막기 위해 오늘의 퀴즈 생성 로직에 중복 체크 추가

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #205
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 중복된 데일리 퀴즈가 추가되지 않도록 중복 검사 로직이 개선되었습니다.

* **기타 개선**
  * 퀴즈 생성 시 재시도 횟수가 3회에서 5회로 증가하여 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->