### PR TITLE
[refactor] 가짜 뉴스 생성, 키워드 생성 실패시 안전장치 마련

### DIFF
--- a/src/main/java/com/back/domain/news/fake/service/FakeNewsService.java
+++ b/src/main/java/com/back/domain/news/fake/service/FakeNewsService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
@@ -44,8 +45,6 @@ public class FakeNewsService {
     @Autowired
     @Qualifier("newsExecutor")
     private Executor executor;
-
-
 
     @Async("newsExecutor")
     public CompletableFuture<List<FakeNewsDto>> generateFakeNewsBatch(List<RealNewsDto> realNewsDtos) {
@@ -83,10 +82,8 @@ public class FakeNewsService {
                 .toList();;
 
         return completedFuture(results);
-
     }
 
-    @Transactional
     public List<FakeNewsDto> generateAndSaveAllFakeNews(List<RealNewsDto> realNewsDtos){
         try{
             List<FakeNewsDto> fakeNewsDtos = generateFakeNewsBatch(realNewsDtos).get();
@@ -97,11 +94,11 @@ public class FakeNewsService {
             }
 
             saveAllFakeNews(fakeNewsDtos);
-
             return fakeNewsDtos;
+
         } catch (Exception e){
             log.error("가짜 뉴스 생성 및 저장 실패: {}", e.getMessage());
-            throw new RuntimeException("가짜 뉴스 생성 및 저장 실패", e);
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/com/back/global/ai/processor/KeywordGeneratorProcessor.java
+++ b/src/main/java/com/back/global/ai/processor/KeywordGeneratorProcessor.java
@@ -2,9 +2,14 @@ package com.back.global.ai.processor;
 
 import com.back.domain.news.common.dto.KeywordGenerationReqDto;
 import com.back.domain.news.common.dto.KeywordGenerationResDto;
+import com.back.domain.news.common.dto.KeywordWithType;
+import com.back.domain.news.common.enums.KeywordType;
+import com.back.domain.news.fake.dto.FakeNewsDto;
 import com.back.global.exception.ServiceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.ai.chat.model.ChatResponse;
+
+import java.util.List;
 
 /**
  * 뉴스 제목과 본문을 기반 상세 퀴즈 3개를 생성하는 AI 요청 Processor 입니다.
@@ -175,13 +180,49 @@ public class KeywordGeneratorProcessor implements AiRequestProcessor<KeywordGene
                     KeywordGenerationResDto.class
             );
         } catch (Exception e) {
-            throw new ServiceException(500, "AI 응답이 JSON 형식이 아닙니다. 응답 : " + cleanedJson);
+            return createDefaultCase();
         }
 
         validatekeywords(result);
 
         return result;
 
+    }
+
+    private KeywordGenerationResDto createDefaultCase() {
+
+        List<KeywordWithType> societyKeywords = List.of(
+                new KeywordWithType("사회", KeywordType.GENERAL),
+                new KeywordWithType("교육", KeywordType.GENERAL)
+        );
+
+        List<KeywordWithType> economyKeywords = List.of(
+                new KeywordWithType("경제", KeywordType.GENERAL),
+                new KeywordWithType("시장", KeywordType.GENERAL)
+        );
+
+        List<KeywordWithType> politicsKeywords = List.of(
+                new KeywordWithType("정치", KeywordType.GENERAL),
+                new KeywordWithType("정부", KeywordType.GENERAL)
+        );
+
+        List<KeywordWithType> cultureKeywords = List.of(
+                new KeywordWithType("문화", KeywordType.GENERAL),
+                new KeywordWithType("예술", KeywordType.GENERAL)
+        );
+
+        List<KeywordWithType> itKeywords = List.of(
+                new KeywordWithType("기술", KeywordType.GENERAL),
+                new KeywordWithType("IT", KeywordType.GENERAL)
+        );
+
+        return new KeywordGenerationResDto(
+                societyKeywords,
+                economyKeywords,
+                politicsKeywords,
+                cultureKeywords,
+                itKeywords
+        );
     }
 
     private void validatekeywords(KeywordGenerationResDto result) {


### PR DESCRIPTION
## 📢 기능 설명

ai호출로 생성 실패 시 default case반환 처리
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #209
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 키워드 생성 과정에서 AI 오류 발생 시, 기본 키워드 세트로 안전하게 대체되어 서비스가 중단되지 않도록 개선되었습니다.
  * 가짜 뉴스 생성 중 예외 발생 시, 빈 목록을 반환하여 오류로 인한 서비스 중단을 방지하였습니다.

* **기타**
  * 일부 불필요한 코드 및 주석이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->