### PR TITLE
[feat] DB 순환참조 방지

### DIFF
--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.member.entity;
 
 import com.back.domain.member.quizhistory.entity.QuizHistory;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
@@ -55,6 +56,7 @@ public class Member {
 
     // 유저가 푼 퀴즈 기록을 저장하는 리스트 일단 엔티티 없어서 주석
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @JsonIgnore
     private List<QuizHistory> quizHistories = new ArrayList<>(); //유저가 퀴즈를 푼 기록
 
 

--- a/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
+++ b/src/main/java/com/back/domain/news/fake/entity/FakeNews.java
@@ -2,6 +2,7 @@ package com.back.domain.news.fake.entity;
 
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.fact.entity.FactQuiz;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -36,12 +37,14 @@ public class FakeNews {
     @OneToOne
     @MapsId // 진짜뉴스의 ID를 이 엔티티의 PK로 사용
     @JoinColumn(name = "real_news_id")
+    @JsonIgnore
     private RealNews realNews;
 
     @Lob
     private String content;
 
     @OneToMany(mappedBy = "fakeNews", cascade = ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<FactQuiz> factQuizzes = new ArrayList<>();
 
 }

--- a/src/main/java/com/back/domain/news/real/entity/RealNews.java
+++ b/src/main/java/com/back/domain/news/real/entity/RealNews.java
@@ -5,6 +5,7 @@ import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.fake.entity.FakeNews;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
 import com.back.domain.quiz.fact.entity.FactQuiz;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,12 +46,15 @@ public class RealNews {
 
     // 상세 퀴즈와 1:N 관계 설정 (RealNews 하나 당 3개의 DetailQuiz가 생성됩니다.)
     @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<DetailQuiz> detailQuizzes = new ArrayList<>();
 
     @OneToMany(mappedBy = "realNews", cascade = ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<FactQuiz> factQuizzes = new ArrayList<>();
 
     @OneToOne(mappedBy = "realNews", cascade = ALL, fetch = LAZY)
+    @JsonIgnore
     private FakeNews fakeNews;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/back/domain/news/today/entity/TodayNews.java
+++ b/src/main/java/com/back/domain/news/today/entity/TodayNews.java
@@ -2,6 +2,7 @@ package com.back.domain.news.today.entity;
 
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,10 +24,12 @@ public class TodayNews {
     @OneToOne
     @MapsId
     @JoinColumn(name = "real_news_id")
+    @JsonIgnore
     private RealNews realNews;
 
     // 오늘의 퀴즈와 1:N 관계 설정
     @OneToMany(mappedBy = "todayNews", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<DailyQuiz> todayQuizzes = new ArrayList<>();
 
 

--- a/src/main/java/com/back/domain/quiz/daily/entity/DailyQuiz.java
+++ b/src/main/java/com/back/domain/quiz/daily/entity/DailyQuiz.java
@@ -3,6 +3,7 @@ package com.back.domain.quiz.daily.entity;
 import com.back.domain.news.today.entity.TodayNews;
 import com.back.domain.quiz.QuizType;
 import com.back.domain.quiz.detail.entity.DetailQuiz;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -20,10 +21,12 @@ public class DailyQuiz {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "today_news_id")
+    @JsonIgnore
     private TodayNews todayNews;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "detail_quiz_id", unique = true)
+    @JsonIgnore
     private DetailQuiz detailQuiz;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
+++ b/src/main/java/com/back/domain/quiz/detail/entity/DetailQuiz.java
@@ -4,6 +4,7 @@ import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.QuizType;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -36,6 +37,7 @@ public class DetailQuiz {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "real_news_id")
+    @JsonIgnore
     private RealNews realNews;
 
     @Enumerated(EnumType.STRING)
@@ -44,6 +46,7 @@ public class DetailQuiz {
 
     // 오늘의 퀴즈와 1:1 관계 설정
     @OneToOne(mappedBy = "detailQuiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private DailyQuiz dailyQuiz;
 
 

--- a/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
+++ b/src/main/java/com/back/domain/quiz/fact/entity/FactQuiz.java
@@ -3,6 +3,7 @@ package com.back.domain.quiz.fact.entity;
 import com.back.domain.news.fake.entity.FakeNews;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.quiz.QuizType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -27,11 +28,13 @@ public class FactQuiz {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "real_news_id", nullable = false)
+    @JsonIgnore
     @NotNull
     private RealNews realNews;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fake_news_id", nullable = false)
+    @JsonIgnore
     @NotNull
     private FakeNews fakeNews;
 


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #255 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 뉴스·퀴즈 엔티티 간 순환 참조로 인한 JSON 직렬화 오류를 해결했습니다(관련 연관 필드들을 직렬화에서 제외).
- 성능 개선
  - 불필요한 연관 데이터 직렬화를 제거해 응답 페이로드를 축소하고 처리 속도를 개선했습니다.
- 안정성
  - 중첩된 연관 데이터로 인한 오류(스택 오버플로우, 타임아웃 등) 발생 가능성을 낮췄습니다.
- 문서
  - 없음
- 테스트
  - 없음
- 기타
  - 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->