### PR TITLE
[feat] 형태소 분석과 비트마스킹을 통한 유사도 검사후 중복 기사 제거

### DIFF
--- a/.github/workflows/wakeup-scheduler.yml
+++ b/.github/workflows/wakeup-scheduler.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wake up app
-        run: curl -f https://news-ox.fly.dev/
+        run: curl -f https://news-ox.fly.dev/health

--- a/src/main/java/com/back/dev/controller/DevTestController.java
+++ b/src/main/java/com/back/dev/controller/DevTestController.java
@@ -3,10 +3,10 @@ package com.back.dev.controller;
 import com.back.dev.service.DevTestNewsService;
 import com.back.domain.news.common.dto.NaverNewsDto;
 import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.service.NewsDataService;
 import com.back.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -14,15 +14,16 @@ import java.util.*;
 @Profile("!prod")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/test")
+@RequestMapping("/ntest")
 public class DevTestController {
 
     private final DevTestNewsService devTestNewsService;
+    private final NewsDataService newsDataService;
 
     @GetMapping("/news")
-    public RsData<List<RealNewsDto>> testCreateNews(){
+    public RsData<List<NaverNewsDto>> testCreateNews(){
 
-        List<RealNewsDto> testNews;
+        List<NaverNewsDto> testNews;
 
         try{
             testNews =  devTestNewsService.testNewsDataService();
@@ -34,27 +35,12 @@ public class DevTestController {
     }
 
     @GetMapping("/fetch")
-    public RsData<List<Map<String, String>>> testFetch(@RequestParam String query){
+    public RsData<List<NaverNewsDto>> testFetch(@RequestParam String query){
         List<NaverNewsDto> testNews = devTestNewsService.fetchNews(query);
 
-        List<String> titles = testNews.stream()
-                .map(NaverNewsDto::title)
-                .toList();
-
-        List<Map<String,String>> extractdupKeywords = new ArrayList<>();
-        for(String title : titles){
-            List<String> keywords = devTestNewsService.extractKeywords(title);
-            Map<String, String> map = new HashMap<>();
-            map.put("title", title);
-            map.put("keywords", String.join(",", keywords));
-            extractdupKeywords.add(map);
-        }
-        return RsData.of(200, "테스트 뉴스 메타데이터 생성 완료", extractdupKeywords);
+        return RsData.of(200, "테스트 뉴스 메타데이터 생성 완료", testNews);
     }
 
-    @GetMapping("/keyword")
-    public List<String> getExtractedWord(@RequestParam String keyword){
 
-        return devTestNewsService.extractKeywords(keyword);
-    }
+
 }

--- a/src/main/java/com/back/dev/service/DevTestNewsService.java
+++ b/src/main/java/com/back/dev/service/DevTestNewsService.java
@@ -35,7 +35,6 @@ import static scala.collection.JavaConverters.*;
 @Service
 public class DevTestNewsService {
     private final NewsDataService newsDataService;
-    private final NewsAnalysisService newsAnalysisService;
     private final RestTemplate restTemplate;
 
     @Value("${NAVER_CLIENT_ID}")
@@ -56,108 +55,20 @@ public class DevTestNewsService {
     @Value("${naver.base-url}")
     private String naverUrl;
 
-    public List<RealNewsDto> testNewsDataService() {
-        List<String> newsKeywordsAfterAdd = List.of("AI");
+    public List<NaverNewsDto> testNewsDataService() {
+        List<String> newsKeywordsAfterAdd = List.of("AI", "사고");
+        List<NaverNewsDto> newsAfterRemoveDup = newsDataService.collectMetaDataFromNaver(newsKeywordsAfterAdd);
 
-        List<NaverNewsDto> newsMetaData = newsDataService.collectMetaDataFromNaver(newsKeywordsAfterAdd);
+//        List<RealNewsDto> newsAfterCrwal = newsDataService.createRealNewsDtoByCrawl(newsAfterRemoveDup);
+//
+//        List<AnalyzedNewsDto> newsAfterFilter = newsAnalysisService.filterAndScoreNews(newsAfterCrwal);
+//
+//        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(newsAfterFilter);
+//
+//        List<RealNewsDto> savedNews = newsDataService.saveAllRealNews(selectedNews);
 
-        List<RealNewsDto> newsAfterCrwal = newsDataService.createRealNewsDtoByCrawl(newsMetaData);
-
-        List<AnalyzedNewsDto> newsAfterFilter = newsAnalysisService.filterAndScoreNews(newsAfterCrwal);
-
-        List<RealNewsDto> selectedNews = newsDataService.selectNewsByScore(newsAfterFilter);
-
-        List<RealNewsDto> savedNews = newsDataService.saveAllRealNews(selectedNews);
-
-        return savedNews;
+        return newsAfterRemoveDup;
     }
-
-    public List<String> extractKeywords(String text) {
-        try {
-
-            List<String> keywords = new ArrayList<>();
-
-            // OpenKoreanTextProcessor로 중복 체크
-            String normalized = normalize(text).toString();
-            List<KoreanTokenJava> tokenList = tokensToJavaKoreanTokenList(
-                    tokenize(normalized)
-            );
-
-            for (KoreanTokenJava token : tokenList) {
-                String pos = token.getPos().toString();
-                System.out.printf("토큰: %s, 품사: %s\n", token.getText(), pos);
-
-                // 조사, 어미, 구두점만 제외하고 나머지는 모두 포함
-                if (!pos.contains("Josa") && !pos.contains("Eomi") &&
-                        !pos.contains("Punctuation") && !pos.contains("Space")) {
-
-                    if(pos.equals("Adjective") || pos.equals("Verb")) {
-                        // Adjective, Verb, Adverb 이고 기본형이 있는 경우
-                        String stem = token.getStem();
-                        if (stem != null) {
-                            System.out.println("기본형: " + stem);
-                            // 같은 offset을 가진 토큰은 하나로 묶기
-                            keywords.add(stem);
-                            continue;
-                        }else{
-                            System.out.println("기본형 없음, 원본 토큰 사용: " + token.getText());
-                        }
-                    }
-
-                    keywords.add(token.getText());
-                }
-            }
-            return keywords;
-
-        } catch (Exception e) {
-            // 형태소 분석 실패 시 단순 공백 기준 분리 (조사 포함)
-            return List.of(text.split("\\s+"));
-        }
-    }
-
-    // 단순하지만 실용적인 키워드 추출
-//    public Set<String> extractKeywords(String text) {
-//        try {
-//
-//            Set<String> keywords = new HashSet<>();
-//
-//            // 1. OpenKoreanTextProcessor로 조사 제거
-//            String normalized = normalize(text).toString();
-//            List<String> tokens = tokensToJavaStringList(tokenize(normalized));
-//            List<KoreanTokenJava> tokenList = tokensToJavaKoreanTokenList(
-//                    tokenize(normalized)
-//            );
-//            StringBuilder processedText = new StringBuilder();
-//            for (KoreanTokenJava token : tokenList) {
-//                String pos = token.getPos().toString();
-//
-//                // 조사, 어미, 구두점만 제외하고 나머지는 모두 포함
-//                if (!pos.contains("Josa") && !pos.contains("Eomi") &&
-//                        !pos.contains("Punctuation") && !pos.contains("Space")) {
-//                    processedText.append(token.getText()).append(" ");
-//                }
-//            }
-//
-//            // 2. 조사가 제거된 텍스트를 공백 기준으로 분리
-//            String[] words = processedText.toString().trim().split("\\s+");
-//
-//            for (String word : words) {
-//                // 길이 2 이상이고, 완전 숫자가 아닌 것만 포함
-//                if (word.length() >= 2 && !word.matches("^[0-9]+$")) {
-//                    keywords.add(word.trim());
-//                }
-//            }
-//
-//            return keywords;
-//
-//        } catch (Exception e) {
-//            // 형태소 분석 실패 시 단순 공백 기준 분리 (조사 포함)
-//            return Arrays.stream(text.replaceAll("<[^>]*>", "").split("\\s+"))
-//                    .filter(word -> word.length() >= 2)
-//                    .filter(word -> !word.matches("^[0-9]+$"))
-//                    .collect(Collectors.toSet());
-//        }
-//    }
 
     public List<NaverNewsDto> fetchNews(String query) {
 
@@ -184,6 +95,7 @@ public class DevTestNewsService {
                 // readTree(): json 문자열을 JsonNode 트리로 변환
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode items = mapper.readTree(response.getBody()).get("items");
+
 
                 if (items != null) {
                     return getNewsMetaDataFromNaverApi(items);

--- a/src/main/java/com/back/domain/news/real/service/NewsDataService.java
+++ b/src/main/java/com/back/domain/news/real/service/NewsDataService.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.openkoreantext.processor.KoreanTokenJava;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -42,8 +43,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.openkoreantext.processor.OpenKoreanTextProcessorJava.*;
 
 @Slf4j
 @Service
@@ -78,6 +82,12 @@ public class NewsDataService {
     @Value("${naver.base-url}")
     private String naverUrl;
 
+    @Value("#{0.15}") // 요약본 임계값
+    private double descriptionSimilarityThreshold;
+
+    @Value("#{0.2}") // 제목 임계값
+    private double titleSimilarityThreshold;
+
     // 서비스 초기화 시 설정값 검증
     @PostConstruct
     public void validateConfig() {
@@ -87,8 +97,8 @@ public class NewsDataService {
         if (clientSecret == null || clientSecret.isEmpty()) {
             throw new IllegalArgumentException("NAVER_CLIENT_SECRET가 설정되지 않았습니다.");
         }
-        if (newsDisplayCount < 1 || newsDisplayCount > 10) {
-            throw new IllegalArgumentException("NAVER_NEWS_DISPLAY_COUNT는 1에서 10 사이의 값이어야 합니다.");
+        if (newsDisplayCount < 1 || newsDisplayCount >= 100) {
+            throw new IllegalArgumentException("NAVER_NEWS_DISPLAY_COUNT는 100이하의 값이어야 합니다.");
         }
         if (crawlingDelay < 0) {
             throw new IllegalArgumentException("NAVER_CRAWLING_DELAY는 0 이상이어야 합니다.");
@@ -171,8 +181,8 @@ public class NewsDataService {
         try {
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
 
-            for (int i = 0; i < futures.size(); i++) {
-                List<NaverNewsDto> news = futures.get(i).get();
+            for (CompletableFuture<List<NaverNewsDto>> future : futures) {
+                List<NaverNewsDto> news = future.get();
 
                 List<NaverNewsDto> naverOnly = news.stream()
                         .filter(dto -> dto.link().contains("n.news.naver.com"))
@@ -188,31 +198,115 @@ public class NewsDataService {
             throw new RuntimeException("뉴스 조회 중 오류 발생", e.getCause());
         }
 
-        //API 응답 받은 후 바로 URL 기준 중복 제거
-        List<NaverNewsDto> uniqueNews = removeDuplicateUrls(allNews);
-
-        log.info("API 호출 완료: {}건 → 중복 제거 후: {}건", allNews.size(), uniqueNews.size());
-        return uniqueNews;
-
+        return allNews;
     }
 
-    private List<NaverNewsDto> removeDuplicateUrls(List<NaverNewsDto> newsList) {
-        Map<String, NaverNewsDto> uniqueByUrl = new LinkedHashMap<>();
+    public List<NaverNewsDto> removeDuplicateByBitSetByField(List<NaverNewsDto> metaDataList, Function<NaverNewsDto, String> fieldExtractor, double similarityThreshold) {
+        // 전체 키워드에 인덱스 부여 (존재하는 키워드에 대해 인덱스 부여)
+        Map<String, Integer> keywordIndexMap = new HashMap<>();
+        int idx = 0;
+        List<Set<String>> newsKeywordSets = new ArrayList<>();
 
-        for (NaverNewsDto news : newsList) {
-            String url = news.link();
-            if (!uniqueByUrl.containsKey(url)) {
-                uniqueByUrl.put(url, news);
-            } else {
-                log.debug("중복 URL 제거: {}", url);
+        for (NaverNewsDto news : metaDataList) {
+            Set<String> keywords = extractKeywords(fieldExtractor.apply(news));
+            newsKeywordSets.add(keywords);
+            for (String kw : keywords) {
+                if (!keywordIndexMap.containsKey(kw)) {
+                    keywordIndexMap.put(kw, idx++);
+                }
             }
         }
 
-        return new ArrayList<>(uniqueByUrl.values());
+        // 뉴스 키워드  BitSet 변환(키워드의 인덱스에 대해 BitSet 설정)
+        List<BitSet> newsBitSets = new ArrayList<>();
+        for (Set<String> keywords : newsKeywordSets) {
+            BitSet bs = new BitSet(keywordIndexMap.size());
+            for (String kw : keywords) {
+                bs.set(keywordIndexMap.get(kw));
+            }
+            newsBitSets.add(bs);
+        }
+
+        // 3. BitSet 기반 유사도 비교 및 제거
+        List<NaverNewsDto> filteredNews = new ArrayList<>();
+        boolean[] removed = new boolean[metaDataList.size()];
+        double[] scores = new double[metaDataList.size()];
+
+
+        for (int i = 0; i < newsBitSets.size(); i++) {
+            if (removed[i]) continue;
+            filteredNews.add(metaDataList.get(i));
+
+            for (int j = i + 1; j < newsBitSets.size(); j++) {
+                if (removed[j]) continue;
+
+                // 교집합
+                BitSet intersection = (BitSet) newsBitSets.get(i).clone();
+                intersection.and(newsBitSets.get(j));
+                int interCount = intersection.cardinality();
+
+                // 합집합
+                BitSet union = (BitSet) newsBitSets.get(i).clone();
+                union.or(newsBitSets.get(j));
+                int unionCount = union.cardinality();
+
+                double result = (double) interCount / unionCount;
+
+                if (result > similarityThreshold) {
+//                    log.info("\n\n{}\n{}\n유사도zzz: {}\n", fieldExtractor.apply(metaDataList.get(i)), fieldExtractor.apply(metaDataList.get(j)), result);
+                    removed[j] = true;
+                    scores[j] = result;
+                }
+
+            }
+        }
+
+        log.info("중복 제거 전 : {}개, 중복 제거 후 : {}개",metaDataList.size(), filteredNews.size());
+        return filteredNews;
     }
 
 
-    //
+    public Set<String> extractKeywords(String text) {
+        try {
+            Set<String> keywords = new HashSet<>();
+            // OpenKoreanTextProcessor로 중복 체크
+            String normalized = normalize(text).toString();
+            List<KoreanTokenJava> tokenList = tokensToJavaKoreanTokenList(
+                    tokenize(normalized)
+            );
+
+            for (KoreanTokenJava token : tokenList) {
+                String pos = token.getPos().toString();
+//                System.out.printf("토큰: %s, 품사: %s (%s) \n", token.getText(), pos, Pos.getKorean(pos));
+
+                // 조사, 어미, 구두점만 제외하고 나머지는 모두 포함
+                if (!pos.contains("Josa") && !pos.contains("Eomi") &&
+                        !pos.contains("Punctuation") && !pos.contains("Space")) {
+
+                    if(pos.equals("Adjective") || pos.equals("Verb")) {
+                        // Adjective, Verb, Adverb 이고 기본형이 있는 경우
+                        String stem = token.getStem();
+                        if (stem != null) {
+//                            System.out.println("기본형: " + stem);
+                            // 같은 offset을 가진 토큰은 하나로 묶기
+                            keywords.add(stem);
+                            continue;
+                        }else{
+                            System.out.println("기본형 없음, 원본 토큰 사용: " + token.getText());
+                        }
+                    }
+
+                    keywords.add(token.getText());
+                }
+            }
+            return keywords;
+
+        } catch (Exception e) {
+            // 형태소 분석 실패 시 단순 공백 기준 분리 (조사 포함)
+            return Set.of(text.split("\\s+"));
+        }
+    }
+
     @Async("newsExecutor")
     public CompletableFuture<List<NaverNewsDto>> fetchNews(String keyword) {
         try {
@@ -239,7 +333,29 @@ public class NewsDataService {
                 JsonNode items = objectMapper.readTree(response.getBody()).get("items");
 
                 if (items != null) {
-                    return CompletableFuture.completedFuture(getNewsMetaDataFromNaverApi(items));
+                    List<NaverNewsDto> rawNews = getNewsMetaDataFromNaverApi(items);
+
+                    // 네이버 뉴스만 필터링
+                    List<NaverNewsDto> naverOnly = rawNews.stream()
+                            .filter(dto -> dto.link().contains("n.news.naver.com"))
+                            .toList();
+
+                    // 키워드별로 중복 제거 수행
+                    List<NaverNewsDto> dedupTitle = removeDuplicateByBitSetByField(
+                            naverOnly, NaverNewsDto::title, titleSimilarityThreshold);
+
+                    List<NaverNewsDto> dedupDescription = removeDuplicateByBitSetByField(
+                            dedupTitle, NaverNewsDto::description, descriptionSimilarityThreshold);
+
+                    // 12개로 제한
+                    List<NaverNewsDto> limited = dedupDescription.stream()
+                            .limit(12)
+                            .toList();
+
+                    log.info("키워드 '{}': 원본 {}개 → 중복제거 후 {}개 → 제한 후 {}개",
+                            keyword, naverOnly.size(), dedupDescription.size(), limited.size());
+
+                    return CompletableFuture.completedFuture(limited);
                 }
                 return CompletableFuture.completedFuture(new ArrayList<>());
             }

--- a/src/main/java/com/back/domain/news/real/service/NewsDataService.java
+++ b/src/main/java/com/back/domain/news/real/service/NewsDataService.java
@@ -115,7 +115,6 @@ public class NewsDataService {
 
         try {
             for (NaverNewsDto metaData : MetaDataList) {
-                String url = metaData.link();
 
                 Optional<NewsDetailDto> newsDetailData = crawladditionalInfo(metaData.link());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   base-url: "https://openapi.naver.com/v1/search/news?query="
   news:
-    display: 10
+    display: 50
     sort: sim
   crawling:
     delay: 1000 # 줄이지 말아주세요

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,3 +83,10 @@ keyword:
     recent-days: 5 # 키워드 history 조회 기준
   cleanup:
     retention-days: 5 # 키워드 history 삭제 기준
+news:
+  dedup:
+    title:
+        threshold: 0.2 # 중복 뉴스 제목 유사도 기준
+    description:
+        threshold: 0.15 # 중복 뉴스 내용 유사도 기준
+


### PR DESCRIPTION
## 📢 기능 설명

extractKeyword 메서드 작성(open korean text 사용)하여 형태소 분석 후 키워드 추출
<img width="1657" height="199" alt="image" src="https://github.com/user-attachments/assets/ef88a373-3a09-4a83-bd5a-9f5d4b22b678" />

removeDuplicateByBitSetByField 메서드 작성하여 추출한 키워드를 바탕으로 title과 description에 대한 유사도 검사(비트마스킹 사용)

<img width="1080" height="391" alt="image" src="https://github.com/user-attachments/assets/0f88e955-140b-48ad-a4fe-6329b961de07" />
<img width="1483" height="297" alt="image" src="https://github.com/user-attachments/assets/4b0f5b44-64e0-437d-b97e-fa295a422793" />
두번 필터링 후 남은 뉴스들에 substring으로 잘라 크롤링

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #250 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 네이버 뉴스 표시 수 확대(기본값 10→50) 및 중복 제거 설정 추가(제목·본문 유사도 기준).

- 리팩터링
  - 공개 API 기본 경로 변경으로 엔드포인트 주소 변경.
  - 응답 형식이 가공된 기사 대신 네이버 메타데이터 형태로 일관화됨.
  - 내부 키워드 추출 경로 제거(관련 공개 엔드포인트 삭제).

- 버그 수정/안정성
  - 수집 시 오류 발생 시 명확한 실패 응답(500) 및 예외 처리 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->