### PR TITLE
[feat] 오늘의 뉴스를 항상 최신 오늘의 뉴스로 들고옴

### DIFF
--- a/src/main/java/com/back/dev/controller/DevTestController.java
+++ b/src/main/java/com/back/dev/controller/DevTestController.java
@@ -3,7 +3,9 @@ package com.back.dev.controller;
 import com.back.dev.service.DevTestNewsService;
 import com.back.domain.news.common.dto.NaverNewsDto;
 import com.back.domain.news.real.dto.RealNewsDto;
+import com.back.domain.news.real.repository.RealNewsRepository;
 import com.back.domain.news.real.service.NewsDataService;
+import com.back.domain.news.real.service.RealNewsService;
 import com.back.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -19,6 +21,8 @@ public class DevTestController {
 
     private final DevTestNewsService devTestNewsService;
     private final NewsDataService newsDataService;
+    private final RealNewsService realNewsService;
+    private final RealNewsRepository realNewsRepository;
 
     @GetMapping("/news")
     public RsData<List<NaverNewsDto>> testCreateNews(){
@@ -39,6 +43,23 @@ public class DevTestController {
         List<NaverNewsDto> testNews = devTestNewsService.fetchNews(query);
 
         return RsData.of(200, "테스트 뉴스 메타데이터 생성 완료", testNews);
+    }
+
+    @GetMapping("/today")
+    public RsData<RealNewsDto> getTodayNews() {
+        Long todayNewsId = realNewsService.getTodayNewsOrRecent();
+        System.out.println("=== DEBUG: todayNewsId = " + todayNewsId);
+
+        // DB에서 직접 확인
+        boolean exists = realNewsRepository.existsById(todayNewsId);
+        System.out.println("=== DEBUG: exists in DB = " + exists);
+
+        Optional<RealNewsDto> todayNews = realNewsService.getRealNewsDtoById(todayNewsId);
+        System.out.println("=== DEBUG: found DTO = " + todayNews.isPresent());
+
+        return todayNews
+                .map(news -> RsData.of(200, "오늘의 뉴스 조회 성공", news))
+                .orElseGet(() -> RsData.of(404, "오늘의 뉴스를 찾을 수 없습니다."));
     }
 
 

--- a/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/AdminNewsController.java
@@ -141,10 +141,9 @@ public class AdminNewsController {
             return RsData.of(400, "잘못된 뉴스 ID입니다. 1 이상의 숫자를 입력해주세요.");
         }
 
-        Optional<Long> todayNewsId = realNewsService.getTodayNews()
-                .map(RealNewsDto::id);
+        Long todayNewsId = realNewsService.getTodayNewsOrRecent();
 
-        if (todayNewsId.isPresent() && newsId.equals(todayNewsId.get())) {
+        if (todayNewsId != -1L && newsId.equals(todayNewsId)) {
             return RsData.of(403, "오늘의 뉴스는 탭을 통해 조회해주세요.");
         }
 
@@ -154,7 +153,6 @@ public class AdminNewsController {
             return RsData.of(404,
                     String.format("ID %d에 해당하는 뉴스를 찾을 수 없습니다. 올바른 뉴스 ID인지 확인해주세요.", newsId));
         }
-
 
         return newsPageService.getSingleNews(realNewsDto, NewsType.REAL, newsId);
     }
@@ -167,11 +165,13 @@ public class AdminNewsController {
     })
     @GetMapping("/today")
     public RsData<RealNewsDto> getTodayNews() {
-        Optional<RealNewsDto> todayNews = realNewsService.getTodayNews();
+        Long todayNewsId = realNewsService.getTodayNewsOrRecent();
 
-        if (todayNews.isEmpty()) {
+        if (todayNewsId== -1L) {
             return RsData.of(404, "조회할 뉴스가 없습니다.");
         }
+
+        Optional<RealNewsDto> todayNews = realNewsService.getRealNewsDtoById(todayNewsId);
 
         return newsPageService.getSingleNews(todayNews, NewsType.REAL, todayNews.get().id());
     }

--- a/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
+++ b/src/main/java/com/back/domain/news/real/controller/RealNewsController.java
@@ -6,6 +6,7 @@ import com.back.domain.news.common.service.NewsPageService;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.service.NewsDataService;
 import com.back.domain.news.real.service.RealNewsService;
+import com.back.domain.news.today.entity.TodayNews;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,10 +50,9 @@ public class RealNewsController {
             return RsData.of(400, "잘못된 뉴스 ID입니다. 1 이상의 숫자를 입력해주세요.");
         }
 
-        Optional<Long> todayNewsId = realNewsService.getTodayNews()
-                .map(RealNewsDto::id);
+        Long todayNewsId = realNewsService.getTodayNewsOrRecent();
 
-        if (todayNewsId.isPresent() && newsId.equals(todayNewsId.get())) {
+        if (todayNewsId!= -1L && newsId.equals(todayNewsId)) {
             return RsData.of(403, "오늘의 뉴스는 탭을 통해 조회해주세요.");
         }
 
@@ -74,7 +74,8 @@ public class RealNewsController {
     })
     @GetMapping("/today")
     public RsData<RealNewsDto> getTodayNews() {
-        Optional<RealNewsDto> todayNews = realNewsService.getTodayNews();
+        Long todayNewsId = realNewsService.getTodayNewsOrRecent();
+        Optional<RealNewsDto> todayNews = realNewsService.getRealNewsDtoById(todayNewsId);
 
         if (todayNews.isEmpty()) {
             return RsData.of(404, "조회할 뉴스가 없습니다.");

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.java
@@ -13,22 +13,7 @@ import java.util.Optional;
 
 
 public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
-    Page<RealNews> findByTitleContaining(String title, Pageable pageable);
 
-    Page<RealNews> findByNewsCategory(NewsCategory category, Pageable pageable);
-
-    Page<RealNews> findByTitleContainingAndIdNot(String title, Long excludedId, Pageable pageable);
-
-    Page<RealNews> findByIdNot(Long excludedId, Pageable pageable);
-
-    Page<RealNews> findByNewsCategoryAndIdNot(NewsCategory category, Long excludedId, Pageable pageable);
-
-
-    boolean existsByLink(String url);
-
-    List<RealNews> findByCreatedDateBetween(LocalDateTime start, LocalDateTime end);
-
-    // 제목 검색 (Fulltext) + N번째 제외 (카테고리별 랭킹 제외)
     // 제목 검색 (Fulltext) + N번째 제외 (카테고리별 랭킹 제외)
     @Query(value = """
     WITH ranked AS (
@@ -165,15 +150,6 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     Page<RealNews> findByIdNotOrderByCreatedDateDesc(Long excludedId, Pageable pageable);
     Page<RealNews> findByNewsCategoryAndIdNotOrderByCreatedDateDesc(NewsCategory category, Long excludedId, Pageable pageable);
     Page<RealNews> findByTitleContainingAndIdNotOrderByCreatedDateDesc(String title, Long excludedId, Pageable pageable);
-
-    // 제목 검색 - 대소문자 무시 + 정렬 (인덱스: idx_real_news_title 활용)
-    @Query("SELECT rn FROM RealNews rn WHERE LOWER(rn.title) LIKE LOWER(CONCAT('%', :title, '%')) ORDER BY rn.createdDate DESC")
-    Page<RealNews> findByTitleContainingIgnoreCaseOrderByCreatedDateDesc(@Param("title") String title, Pageable pageable);
-
-
-    // 관리자용 원본 날짜순 조회 (인덱스: idx_real_news_origin_created_date_desc)
-    @Query("SELECT rn FROM RealNews rn ORDER BY rn.originCreatedDate DESC")
-    Page<RealNews> findAllByOriginCreatedDateDesc(Pageable pageable);
 
     // 날짜 범위 조회 - 정렬 추가로 인덱스 활용 개선
     @Query("SELECT rn FROM RealNews rn WHERE rn.createdDate BETWEEN :start AND :end ORDER BY rn.createdDate DESC")

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -118,9 +118,11 @@ public class RealNewsService {
         return page.map(realNewsMapper::toDto);
     }
 
+    @Transactional(readOnly = true)
     public Long getTodayNewsOrRecent() {
         return todayNewsRepository.findTopByOrderBySelectedDateDesc()
-                .map(todayNews -> todayNews.getRealNews().getId())
+                .map(TodayNews::getRealNews)
+                .map(RealNews::getId)
                 .orElse(-1L);
     }
 }

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -1,11 +1,11 @@
 package com.back.domain.news.real.service;
 
-
 import com.back.domain.news.common.enums.NewsCategory;
 import com.back.domain.news.real.dto.RealNewsDto;
 import com.back.domain.news.real.entity.RealNews;
 import com.back.domain.news.real.mapper.RealNewsMapper;
 import com.back.domain.news.real.repository.RealNewsRepository;
+import com.back.domain.news.today.entity.TodayNews;
 import com.back.domain.news.today.repository.TodayNewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,11 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
-
-import com.back.domain.news.today.entity.TodayNews;
 
 @Service
 @RequiredArgsConstructor
@@ -36,28 +34,11 @@ public class RealNewsService {
     }
 
     @Transactional(readOnly = true)
-    public Page<RealNewsDto> getRealNewsList(Pageable pageable) {
-        Long excludedId = getTodayNewsOrRecent();
-
-        return realNewsRepository.findByIdNotOrderByCreatedDateDesc(excludedId, pageable)
-                .map(realNewsMapper::toDto);
-    }
-
-    @Transactional(readOnly = true)
     public Page<RealNewsDto> searchRealNewsByTitle(String title, Pageable pageable) {
         Long excludedId = getTodayNewsOrRecent();
 
         return realNewsRepository.findByTitleContainingAndIdNotOrderByCreatedDateDesc(title, excludedId, pageable)
                 .map(realNewsMapper::toDto);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<RealNewsDto> getTodayNews() {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        return todayNewsRepository.findBySelectedDate(today)
-                .map(TodayNews::getRealNews)        // TodayNews -> RealNews
-                .map(realNewsMapper::toDto);
-
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.java
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.java
@@ -120,7 +120,7 @@ public class RealNewsService {
 
     public Long getTodayNewsOrRecent() {
         return todayNewsRepository.findTopByOrderBySelectedDateDesc()
-                .map(TodayNews::getId)
+                .map(todayNews -> todayNews.getRealNews().getId())
                 .orElse(-1L);
     }
 }

--- a/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
+++ b/src/main/java/com/back/domain/news/today/repository/TodayNewsRepository.java
@@ -16,4 +16,5 @@ public interface TodayNewsRepository extends JpaRepository<TodayNews, Long> {
 
     Optional<TodayNews> findBySelectedDate(LocalDate today);
 
+    Optional<TodayNews> findTopByOrderBySelectedDateDesc();
 }


### PR DESCRIPTION
## 📢 기능 설명

기존엔 날짜를 기반으로 들고와서 배치가 실패하면 조회가 안됐음
수정하여 항상 오늘의 뉴스를 최신 오늘의 뉴스로 들고오게함
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #262 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 제목 기반 전체 텍스트 검색과 최신순 정렬로 검색 정확도 향상.
  - 카테고리별/전체 랭킹 조회 및 특정 N위 항목 제외 기능 추가로 맞춤형 리스트 구성 가능.
  - 오늘의 뉴스가 없을 때 최신 항목을 기준으로 처리하여 목록 품질 유지.
  - 개발용 엔드포인트 추가로 오늘의 뉴스 조회(디버그 로깅 포함) 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->